### PR TITLE
Changhe the guid to match r2 implementation

### DIFF
--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -48,7 +48,7 @@ object iTunesRssFeed {
               <link>http://www.theguardian.com</link>
             </image>
             {
-              for (p <- podcasts) yield new iTunesRssItem(p).toXml
+              for (p <- podcasts) yield new iTunesRssItem(p, tag.id).toXml
             }
           </channel>
         </rss>

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -4,7 +4,7 @@ import com.gu.contentapi.client.model.v1._
 import java.text.SimpleDateFormat
 import scala.xml.Node
 
-class iTunesRssItem(val podcast: Content) {
+class iTunesRssItem(val podcast: Content, val tagId: String) {
 
   def toXml: Node = {
 
@@ -33,7 +33,13 @@ class iTunesRssItem(val podcast: Content) {
       format.format(lastModified)
     }
 
-    val guid = asset.flatMap(_.file).getOrElse("")
+    /* Old content served from http(s)://static(-secure).guim.co.uk/{...} will have the guid field set
+    to http://download.guardian.co.uk/{...} for legacy reasons (to match the R2 implementation);
+    new content served from https://audio.guim.co.uk will preserve its structure. */
+
+    val capiUrl = asset.flatMap(_.file).getOrElse("")
+    val regex = s"""https?://static(-secure)?.guim.co.uk/audio/kip/$tagId"""
+    val guid = capiUrl.replaceAll(regex, "http://download.guardian.co.uk/draft/audio")
 
     val duration = {
       val seconds = typeData.flatMap(_.durationSeconds)

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -26,7 +26,7 @@ object Application extends Controller {
       .showElements("audio")
       .showTags("keyword")
       .showFields("all")
-      .pageSize(2) // TODO check this value
+      .pageSize(5) // TODO check this value
 
     client.getResponse(query) map { itemResponse =>
       itemResponse.status match {

--- a/test/com/gu/ItunesRssItemSpec.scala
+++ b/test/com/gu/ItunesRssItemSpec.scala
@@ -9,7 +9,8 @@ class ItunesRssPodcastsSpec extends FlatSpec with ItunesTestData with Matchers {
   it should "check that the produced XML for the podcasts is consistent" in {
 
     val results = itunesCapiResponse.results
-    val podcasts = for (p <- results) yield new iTunesRssItem(p).toXml
+    val tagId = itunesCapiResponse.tag.get.id
+    val podcasts = for (p <- results) yield new iTunesRssItem(p, tagId).toXml
     val trimmedPodcasts = for (p <- podcasts) yield trim(p)
 
     val expectedXml = RemoveWhitespace.transform(
@@ -23,7 +24,7 @@ class ItunesRssPodcastsSpec extends FlatSpec with ItunesTestData with Matchers {
         <enclosure url="http://static.guim.co.uk/audio/kip/science/series/science/1447948283860/6835/gdn.sci.151120.ic.Science_Weekly_2.mp3" length="0" type="audio/mpeg"/>
         <pubDate>Fri, 20 Nov 2015 07:30:00 GMT</pubDate>
         <guid>
-          http://static.guim.co.uk/audio/kip/science/series/science/1447948283860/6835/gdn.sci.151120.ic.Science_Weekly_2.mp3
+          http://download.guardian.co.uk/draft/audio/1447948283860/6835/gdn.sci.151120.ic.Science_Weekly_2.mp3
         </guid>
         <itunes:duration>00:29:07</itunes:duration>
         <itunes:author>theguardian.com</itunes:author>
@@ -44,7 +45,7 @@ class ItunesRssPodcastsSpec extends FlatSpec with ItunesTestData with Matchers {
         <enclosure url="http://static.guim.co.uk/audio/kip/science/series/science/1447432633353/5114/gdn.sci.151116.ic.Science_Weekly.mp3" length="0" type="audio/mpeg"/>
         <pubDate>Fri, 13 Nov 2015 17:11:00 GMT</pubDate>
         <guid>
-          http://static.guim.co.uk/audio/kip/science/series/science/1447432633353/5114/gdn.sci.151116.ic.Science_Weekly.mp3
+          https://audio.guim.co.uk/2015/12/03-53462-gdn.tech.151203.sb.digital-babysitting.mp3
         </guid>
         <itunes:duration>00:27:00</itunes:duration>
         <itunes:author>theguardian.com</itunes:author>
@@ -65,7 +66,7 @@ class ItunesRssPodcastsSpec extends FlatSpec with ItunesTestData with Matchers {
         <enclosure url="http://static.guim.co.uk/audio/kip/science/series/science/1446638390950/3741/gdn.sci.151106.ic.Science_Weekly.mp3" length="0" type="audio/mpeg"/>
         <pubDate>Fri, 06 Nov 2015 07:30:00 GMT</pubDate>
         <guid>
-          http://static.guim.co.uk/audio/kip/science/series/science/1446638390950/3741/gdn.sci.151106.ic.Science_Weekly.mp3
+          http://download.guardian.co.uk/draft/audio/1446638390950/3741/gdn.sci.151106.ic.Science_Weekly.mp3
         </guid>
         <itunes:duration>00:25:37</itunes:duration>
         <itunes:author>theguardian.com</itunes:author>

--- a/test/resources/itunes-capi-response.json
+++ b/test/resources/itunes-capi-response.json
@@ -145,7 +145,7 @@
               {
                 "type": "audio",
                 "mimeType": "audio/mpeg",
-                "file": "http://static.guim.co.uk/audio/kip/science/series/science/1447432633353/5114/gdn.sci.151116.ic.Science_Weekly.mp3",
+                "file": "https://audio.guim.co.uk/2015/12/03-53462-gdn.tech.151203.sb.digital-babysitting.mp3",
                 "typeData": {
                   "explicit": "false",
                   "source": "Guardian",

--- a/test/resources/itunes-capi-response.json
+++ b/test/resources/itunes-capi-response.json
@@ -220,7 +220,7 @@
               {
                 "type": "audio",
                 "mimeType": "audio/mpeg",
-                "file": "http://static.guim.co.uk/audio/kip/science/series/science/1446638390950/3741/gdn.sci.151106.ic.Science_Weekly.mp3",
+                "file": "https://static-secure.guim.co.uk/audio/kip/science/series/science/1446638390950/3741/gdn.sci.151106.ic.Science_Weekly.mp3",
                 "typeData": {
                   "explicit": "false",
                   "source": "Guardian",


### PR DESCRIPTION
1. Changed the `guid` field to match the R2 implementation:
    * old content served from `http(s)://static(-secure).guim.co.uk/{...}` will have the `guid` field se to `http://download.guardian.co.uk/{...}` for legacy reasons (to match the R2 implementation);
    * new content served from `https://audio.guim.co.uk` will preserve its structure
2. Regardless, the actual download url remains `static.guim.co.uk` since using `download.guardian.co.uk` is deprecated [1]
3. The number of podcasts per feed has been bumped up to 5 for testing purposes.

[1] source: Stephen Goldthorpe via email