### PR TITLE
Fix explicit to be no rather than empty

### DIFF
--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -35,9 +35,10 @@ object iTunesRssFeed {
             </itunes:owner>
             <itunes:image href={ podcast.image.getOrElse("") }/>
             <itunes:author>theguardian.com</itunes:author>
-            <itunes:explicit>
-              { if (podcast.explicit) "yes" else "" }
-            </itunes:explicit>
+            {
+              if (podcast.explicit)
+                <itunes:explicit>yes</itunes:explicit>
+            }
             <itunes:keywords/>
             <itunes:summary>{ tag.description.getOrElse("") }</itunes:summary>
             <image>

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -51,7 +51,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String) {
     val explicit = {
       val exp = typeData.flatMap(_.explicit).getOrElse(false)
       val cln = typeData.flatMap(_.clean).getOrElse(false)
-      if (exp) "yes" else if (cln) "clean" else ""
+      if (exp) Some("yes") else if (cln) Some("clean") else None
     }
 
     val keywords = makeKeywordsList(podcast.tags)
@@ -68,7 +68,12 @@ class iTunesRssItem(val podcast: Content, val tagId: String) {
       <guid>{ guid }</guid>
       <itunes:duration>{ duration }</itunes:duration>
       <itunes:author>theguardian.com</itunes:author>
-      <itunes:explicit>{ explicit }</itunes:explicit>
+      {
+        explicit match {
+          case Some(value) => <itunes:explicit>{ value }</itunes:explicit>
+          case None =>
+        }
+      }
       <itunes:keywords>{ keywords }</itunes:keywords>
       <itunes:subtitle>{ subtitle }</itunes:subtitle>
       <itunes:summary>{ summary }</itunes:summary>

--- a/test/com/gu/ItunesRssFeedSpec.scala
+++ b/test/com/gu/ItunesRssFeedSpec.scala
@@ -27,7 +27,6 @@ class ItunesRssFeedSpec extends FlatSpec with ItunesTestData with Matchers {
           </itunes:owner>
           <itunes:image href="http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/4/22/1398182483649/ScienceWeekly.png"/>
           <itunes:author>theguardian.com</itunes:author>
-          <itunes:explicit></itunes:explicit>
           <itunes:keywords/>
           <itunes:summary>
             The Guardian's science team bring you the best analysis and interviews from the worlds of science and technology

--- a/test/com/gu/ItunesRssItemSpec.scala
+++ b/test/com/gu/ItunesRssItemSpec.scala
@@ -28,7 +28,6 @@ class ItunesRssItemSpec extends FlatSpec with ItunesTestData with Matchers {
         </guid>
         <itunes:duration>00:29:07</itunes:duration>
         <itunes:author>theguardian.com</itunes:author>
-        <itunes:explicit></itunes:explicit>
         <itunes:keywords>Science, Mathematics</itunes:keywords>
         <itunes:subtitle>
           John Conway sheds light on the true nature of numbers, the beauty lying within maths and why game-playing is so important to mathematical discovery
@@ -49,7 +48,7 @@ class ItunesRssItemSpec extends FlatSpec with ItunesTestData with Matchers {
         </guid>
         <itunes:duration>00:27:00</itunes:duration>
         <itunes:author>theguardian.com</itunes:author>
-        <itunes:explicit></itunes:explicit>
+        <itunes:explicit>yes</itunes:explicit>
         <itunes:keywords>Science, Psychology</itunes:keywords>
         <itunes:subtitle>
           Should we distrust our own ability to reason? Why is debunking conspiracy theories such a risky business? And is David Icke a force for good?
@@ -70,7 +69,7 @@ class ItunesRssItemSpec extends FlatSpec with ItunesTestData with Matchers {
         </guid>
         <itunes:duration>00:25:37</itunes:duration>
         <itunes:author>theguardian.com</itunes:author>
-        <itunes:explicit></itunes:explicit>
+        <itunes:explicit>clean</itunes:explicit>
         <itunes:keywords>Science, David Eagleman, Neuroscience</itunes:keywords>
         <itunes:subtitle>
           Neuroscientist David Eagleman discusses how neuroscience and technology are reshaping how we understand our brains

--- a/test/resources/itunes-capi-response.json
+++ b/test/resources/itunes-capi-response.json
@@ -147,7 +147,7 @@
                 "mimeType": "audio/mpeg",
                 "file": "https://audio.guim.co.uk/2015/12/03-53462-gdn.tech.151203.sb.digital-babysitting.mp3",
                 "typeData": {
-                  "explicit": "false",
+                  "explicit": "true",
                   "source": "Guardian",
                   "durationMinutes": "27",
                   "durationSeconds": "0"
@@ -209,7 +209,7 @@
           "commentable": "false"
         },
         "webUrl": "http://www.theguardian.com/science/audio/2015/nov/06/science-weekly-podcast-story-brain-david-eagleman-neuroscience",
-        "apiUrl": "http://content.guardianapis.com/science/audio/2015/nov/06/science-weekly-podcast-story-brain-david-eagleman-neuroscience",
+        "apiUrl": " ",
         "sectionName": "Science",
         "elements": [
           {
@@ -225,7 +225,8 @@
                   "explicit": "false",
                   "source": "Guardian",
                   "durationMinutes": "25",
-                  "durationSeconds": "37"
+                  "durationSeconds": "37",
+                  "clean": "true"
                 }
               }
             ]


### PR DESCRIPTION
> The <itunes:explicit> tag indicates whether your podcast contains explicit material. You can specify the following values:
>   - Yes | Explicit | True.
>
 If you specify yes, explicit, or true, indicating the presence of explicit content, the iTunes Store displays an Explicit parental advisory graphic for your podcast.
>   -  Clean | No | False.
>
 If you specify clean, no, or false, indicating that none of your podcast episodes contain explicit language or adult content, the iTunes Store displays a Clean parental advisory graphic for your podcast.