### PR TITLE
Add redirection logic to keep audience of an existing podcast channel

### DIFF
--- a/app/com/gu/itunes/Redirection.scala
+++ b/app/com/gu/itunes/Redirection.scala
@@ -1,0 +1,17 @@
+package com.gu.itunes
+
+object Redirection {
+
+  /*
+    iTunes site manager does not allow to change the XML feed location for an existing podcast.
+    this prevents guardian editors to migrate an existing podcast audience to a new tag.    
+  */
+  def redirect(tagId: String): Option[String] = {
+    if (tagId == "film/series/filmweekly") {
+      Some("film/series/the-dailies-podcast")
+    } else {
+      None
+    }
+  }
+
+}

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -2,13 +2,14 @@ package controllers
 
 import com.gu.contentapi.client.GuardianContentApiError
 import com.gu.contentapi.client.model.ItemQuery
-import com.gu.itunes.{ iTunesRssFeed, CustomCapiClient }
+import com.gu.itunes._
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{ DateTimeZone, DateTime }
 import org.scalactic.{ Bad, Good }
 import play.api.Play
 import play.api.Logger
-import play.api.mvc.{ Action, Controller }
+import play.api.mvc.{ Action, Controller, Result }
+import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object Application extends Controller {
@@ -23,6 +24,15 @@ object Application extends Controller {
   private val HTTPDateFormat = DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'").withZone(DateTimeZone.UTC)
 
   def itunesRss(tagId: String) = Action.async {
+    val redirect = Redirection.redirect(tagId)
+    redirect match {
+      case Some(redirectedTagId) => Future.successful(MovedPermanently(routes.Application.itunesRss(redirectedTagId).url))
+      case None => rawRss(tagId)
+    }
+  }
+
+  def rawRss(tagId: String): Future[Result] = {
+
     val client = new CustomCapiClient(apiKey)
 
     val query = ItemQuery(tagId)


### PR DESCRIPTION
We have the following problem:

- Editors have 2 tags [Film weekly](https://www.theguardian.com/film/series/filmweekly) and [The dailies podcast](https://www.theguardian.com/film/series/the-dailies-podcast) (The first is the old one and the second the new one). All new episodes will have soon only `the dailies podcast` only.

- The guardian has to use `site manager` and not `podcasts connect`. The last one [allows to update your itunes feed](https://help.apple.com/itc/podcasts_connect/#/itca489031e0) but not the first one, so we can't update the feed url on the itunes system. 
 
Therefore we do only a `301` from the old podcast xml to the new one. This response updates the iTunes Store with the new feed URL and subscribers continue to receive new episodes automatically.

@na7hangood 