### PR TITLE
Add another redirection to keep audience of an existing podcast channel

### DIFF
--- a/app/com/gu/itunes/Redirection.scala
+++ b/app/com/gu/itunes/Redirection.scala
@@ -9,6 +9,8 @@ object Redirection {
   def redirect(tagId: String): Option[String] = {
     if (tagId == "film/series/filmweekly") {
       Some("film/series/the-dailies-podcast")
+    } else if (tagId == "technology/series/techweekly") {
+      Some("technology/series/chips-with-everything")
     } else {
       None
     }


### PR DESCRIPTION
Similar to the [film weekly to the daily podcast redirection](https://github.com/guardian/itunes-rss/pull/19) we had another redirection from `techweekly` to `chips-with-everything`.