### PR TITLE
Use absolute URL in redirection according to spec

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -23,10 +23,10 @@ object Application extends Controller {
   val cacheControl = s"max-age=$maxAge, stale-while-revalidate=$staleWhileRevalidateSeconds, stale-if-error=$oneDayInSeconds"
   private val HTTPDateFormat = DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'").withZone(DateTimeZone.UTC)
 
-  def itunesRss(tagId: String) = Action.async {
+  def itunesRss(tagId: String) = Action.async { implicit request =>
     val redirect = Redirection.redirect(tagId)
     redirect match {
-      case Some(redirectedTagId) => Future.successful(MovedPermanently(routes.Application.itunesRss(redirectedTagId).url))
+      case Some(redirectedTagId) => Future.successful(MovedPermanently(routes.Application.itunesRss(redirectedTagId).absoluteURL()))
       case None => rawRss(tagId)
     }
   }


### PR DESCRIPTION
From local debugging with `charles`, it looks like apple does not follow relative location redirect. 