### PR TITLE
Use new-feed field to force Apple to https

### DIFF
--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -22,6 +22,9 @@ object iTunesRssFeed {
       case Some(podcast) => Good {
         <rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
           <channel>
+            {
+              if (tag.webTitle == "What would a feminist do?") <itunes:new-feed-url>{ tag.webUrl + "/podcast.xml" }</itunes:new-feed-url>
+            }
             <title>{ tag.webTitle }</title>
             <link>{ tag.webUrl }</link>
             <description>{ description }</description>


### PR DESCRIPTION
Reference: https://help.apple.com/itc/podcasts_connect/#/itca489031e0

For now it is only for a single podcast series. @mchv 

The new feed looks like:

```
<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
<channel>
<itunes:new-feed-url>
https://www.theguardian.com/commentisfree/series/what-would-a-feminist-do
</itunes:new-feed-url>
<title>What would a feminist do?</title>
<link>
https://www.theguardian.com/commentisfree/series/what-would-a-feminist-do
</link>
...
```
