### PR TITLE
Provide a consistent way to migrate RSS feed url

### DIFF
--- a/app/com/gu/itunes/Redirection.scala
+++ b/app/com/gu/itunes/Redirection.scala
@@ -3,17 +3,23 @@ package com.gu.itunes
 object Redirection {
 
   /*
-    iTunes site manager does not allow to change the XML feed location for an existing podcast.
-    this prevents guardian editors to migrate an existing podcast audience to a new tag.    
+    To update a RSS feed URL (it happens when editors want to change tags) we need to:
+      1. return a 301 redirect response for the old feed to the new feed
+      2. use the <itunes:new-feed-url> tag in the new feed to point to the new URL
+
+    Documentation: https://help.apple.com/itc/podcasts_connect/#/itca489031e0
   */
-  def redirect(tagId: String): Option[String] = {
-    if (tagId == "film/series/filmweekly") {
-      Some("film/series/the-dailies-podcast")
-    } else if (tagId == "technology/series/techweekly") {
-      Some("technology/series/chips-with-everything")
-    } else {
-      None
-    }
-  }
+
+  val BaseUrl = "https://www.theguardian.com"
+
+  val redirectsMapping = Map[String, String](
+    "film/series/filmweekly" -> "film/series/the-dailies-podcast",
+    "technology/series/techweekly" -> "technology/series/chips-with-everything",
+    "politics/series/politics-for-humans" -> "us-news/series/politics-for-humans"
+  )
+
+  def redirect(tagId: String): Option[String] = redirectsMapping.get(tagId)
+
+  def isNewFeedUrl(tagId: String): Boolean = redirectsMapping.values.toList.contains(tagId)
 
 }

--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -23,7 +23,9 @@ object iTunesRssFeed {
         <rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
           <channel>
             {
-              if (tag.webTitle == "What would a feminist do?") <itunes:new-feed-url>{ tag.webUrl + "/podcast.xml" }</itunes:new-feed-url>
+              if (Redirection.isNewFeedUrl(tag.id)) {
+                <itunes:new-feed-url>{ s"${tag.webUrl}/podcast.xml" }</itunes:new-feed-url>
+              }
             }
             <title>{ tag.webTitle }</title>
             <link>{ tag.webUrl }</link>


### PR DESCRIPTION
This PR builds on work previously done by Mariot to provide a way to change a podcast RSS feed url, migrating the users in the process.

The official documentation is here: https://help.apple.com/itc/podcasts_connect/#/itca489031e0

The two main steps are:

> 1. Set your web server to return an HTTP 301 redirect response when it receives a request for the old feed.
> 2. Use the `<itunes:new-feed-url>` tag in your new feed to point to the new URL.

Changes specifically to this PR are:

1. Code refactor to make it trivial to do this in the future => just add your new redirect in the `redirectsMapping` `Map()`
2. Add a new redirect for `politics-for-humans podcast`
3. Consistently use the `new-feed-url` tag for old podcasts that have been migrated (we were doing the redirect step only)

To expand on 3), the "what would a feminist do" podcast was a test that we did and doesn't actually need to be migrated, hence it's not in the redirects Map.