### PR TITLE
Update all feeds to https

### DIFF
--- a/app/com/gu/itunes/Redirection.scala
+++ b/app/com/gu/itunes/Redirection.scala
@@ -3,9 +3,12 @@ package com.gu.itunes
 object Redirection {
 
   /*
-    To update a RSS feed URL (it happens when editors want to change tags) we need to:
+    To update a RSS feed URL (it happens when editors want to change tags) we need to either:
       1. return a 301 redirect response for the old feed to the new feed
       2. use the <itunes:new-feed-url> tag in the new feed to point to the new URL
+
+    We're using 301 redirects when we change tags, and the new-feed-url tag to tell Apple
+    to update our feeds to use https.
 
     Documentation: https://help.apple.com/itc/podcasts_connect/#/itca489031e0
   */
@@ -20,7 +23,5 @@ object Redirection {
   )
 
   def redirect(tagId: String): Option[String] = redirectsMapping.get(tagId)
-
-  def isNewFeedUrl(tagId: String): Boolean = redirectsMapping.values.toList.contains(tagId)
 
 }

--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -22,11 +22,12 @@ object iTunesRssFeed {
       case Some(podcast) => Good {
         <rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
           <channel>
-            {
-              if (Redirection.isNewFeedUrl(tag.id)) {
-                <itunes:new-feed-url>{ s"${tag.webUrl}/podcast.xml" }</itunes:new-feed-url>
+            <itunes:new-feed-url>
+              {
+                // tell Apple to update our feeds to https
+                s"${tag.webUrl}/podcast.xml"
               }
-            }
+            </itunes:new-feed-url>
             <title>{ tag.webTitle }</title>
             <link>{ tag.webUrl }</link>
             <description>{ description }</description>


### PR DESCRIPTION
Add a `new-feed-url` tag to all our podcasts to tell Apple to use https. Once all theirs system are updated we can revert https://github.com/guardian/fastly-edge-cache/pull/656

@mchv 

