### PR TITLE
Fix redirection by using https url

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -26,7 +26,7 @@ object Application extends Controller {
   def itunesRss(tagId: String) = Action.async { implicit request =>
     val redirect = Redirection.redirect(tagId)
     redirect match {
-      case Some(redirectedTagId) => Future.successful(MovedPermanently(routes.Application.itunesRss(redirectedTagId).absoluteURL()))
+      case Some(redirectedTagId) => Future.successful(MovedPermanently(routes.Application.itunesRss(redirectedTagId).absoluteURL(true)))
       case None => rawRss(tagId)
     }
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.11")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 


### PR DESCRIPTION
`absoluteURL` has `secure` parameter that need to be set to `true` for redirecting to an `https` location, see [scaladoc](https://www.playframework.com/documentation/2.5.x/api/scala/index.html#play.api.mvc.Call).

This is currently preventing #43 to work properly

I added an upgrade to the latest `2.4.x` play release, before migrating to `2.5.11`