### PR TITLE
iTunes does not seems to like space and carriage return in the XML

### DIFF
--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -22,12 +22,7 @@ object iTunesRssFeed {
       case Some(podcast) => Good {
         <rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
           <channel>
-            <itunes:new-feed-url>
-              {
-                // tell Apple to update our feeds to https
-                s"${tag.webUrl}/podcast.xml"
-              }
-            </itunes:new-feed-url>
+            <itunes:new-feed-url>{s"${tag.webUrl}/podcast.xml"}</itunes:new-feed-url>
             <title>{ tag.webTitle }</title>
             <link>{ tag.webUrl }</link>
             <description>{ description }</description>


### PR DESCRIPTION
Debugging #43 it seems that space and carriage returns break the `itunes:new-feed-url` feature :/