### PR TITLE
Add AMI update as a dependency

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -7,6 +7,8 @@ deployments:
     type: autoscaling
     parameters:
       bucket: content-api-dist
+    dependencies:
+      - podcasts-rss-ami-update
   podcasts-rss-ami-update:
     type: ami-cloudformation-parameter
     app: podcasts-rss


### PR DESCRIPTION
This should avoid `riff-raff` trying to do the deployment at the same time.