### PR TITLE
A few updates to the RSS summary

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -18,11 +18,15 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset) {
     val pubDate = DateSupport.toRssTimeFormat(lastModified)
 
     val membershipCta = {
-      val launchDay = new DateTime(2016, 12, 6, 0, 0)
       val launchDayTIF = new DateTime(2018, 11, 14, 0, 0)
-      if (lastModified.isAfter(launchDay) && tagId == "politics/series/politicsweekly") {
-        """. Please support our work and help us keep the world informed. To fund us, go to https://gu.com/give/podcast"""
-      } else if (lastModified.isAfter(launchDayTIF) && tagId == "news/series/todayinfocus") {
+      val launchDayPW = new DateTime(2016, 12, 6, 0, 0)
+      val launchDayPWNew = new DateTime(2018, 11, 15, 0, 0)
+      if (tagId == "politics/series/politicsweekly") {
+        if (lastModified.isAfter(launchDayPWNew))
+          """. To support The Guardian’s independent journalism, visit https://gu.com/give/podcast"""
+        else if (lastModified.isAfter(launchDayPW))
+          """. Please support our work and help us keep the world informed. To fund us, go to https://gu.com/give/podcast"""
+      } else if (tagId == "news/series/todayinfocus" && lastModified.isAfter(launchDayTIF)) {
         """. To support The Guardian’s independent journalism, visit http://gu.com/todayinfocus/support"""
       } else {
         ""

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -149,7 +149,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset) {
       }
       <itunes:keywords>{ keywords }</itunes:keywords>
       <itunes:subtitle>{ subtitle }</itunes:subtitle>
-      <itunes:summary><![CDATA[{ summary }]]</itunes:summary>
+      <itunes:summary>{ scala.xml.Unparsed("<![CDATA[%s]]>".format(summary)) }</itunes:summary>
     </item>
   }
 

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -26,6 +26,8 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset) {
           """. To support The Guardian’s independent journalism, visit https://gu.com/give/podcast"""
         else if (lastModified.isAfter(launchDayPW))
           """. Please support our work and help us keep the world informed. To fund us, go to https://gu.com/give/podcast"""
+        else
+          ""
       } else if (tagId == "news/series/todayinfocus" && lastModified.isAfter(launchDayTIF)) {
         """. To support The Guardian’s independent journalism, visit http://gu.com/todayinfocus/support"""
       } else {

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -149,7 +149,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset) {
       }
       <itunes:keywords>{ keywords }</itunes:keywords>
       <itunes:subtitle>{ subtitle }</itunes:subtitle>
-      <itunes:summary>{ scala.xml.Unparsed("<![CDATA[%s]]>".format(summary)) }</itunes:summary>
+      <itunes:summary>{ scala.xml.Utility.escape(summary) }</itunes:summary>
     </item>
   }
 

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -23,13 +23,13 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset) {
       val launchDayPWNew = new DateTime(2018, 11, 15, 0, 0)
       if (tagId == "politics/series/politicsweekly") {
         if (lastModified.isAfter(launchDayPWNew))
-          """. To support The Guardian’s independent journalism, visit https://gu.com/give/podcast"""
+          """. To support The Guardian’s independent journalism, visit <a href="https://gu.com/give/podcast">gu.com/give/podcast</a>"""
         else if (lastModified.isAfter(launchDayPW))
           """. Please support our work and help us keep the world informed. To fund us, go to https://gu.com/give/podcast"""
         else
           ""
       } else if (tagId == "news/series/todayinfocus" && lastModified.isAfter(launchDayTIF)) {
-        """. To support The Guardian’s independent journalism, visit http://gu.com/todayinfocus/support"""
+        """. To support The Guardian’s independent journalism, visit <a href="https://gu.com/todayinfocus/support">gu.com/todayinfocus/support</a>"""
       } else {
         ""
       }
@@ -149,7 +149,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset) {
       }
       <itunes:keywords>{ keywords }</itunes:keywords>
       <itunes:subtitle>{ subtitle }</itunes:subtitle>
-      <itunes:summary>{ summary }</itunes:summary>
+      <itunes:summary><![CDATA[{ summary }]]</itunes:summary>
     </item>
   }
 


### PR DESCRIPTION
1. Align the Politics Weekly message with the TIF one
2. Wrap the `itunes:summary` content in the CDATA section, so that we can
3. Embed an HTML link into the summary, so that clients like Overcast interpret it correctly