### PR TITLE
Error in artefact name

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -202,11 +202,11 @@ Resources:
             mkdir -p /etc/gu
             aws s3 cp s3://content-api-config/podcasts-rss/${Stage}/podcasts-rss.conf /etc/gu/podcasts-rss.conf
             aws s3 cp s3://content-api-dist/${Stack}/${Stage}/podcasts-rss/podcasts-rss.service /etc/systemd/system/podcasts-rss.service
-            aws s3 cp s3://content-api-dist/${Stack}/${Stage}/podcasts-rss/podcasts-rss-0.1-SNAPSHOT.tgz .
+            aws s3 cp s3://content-api-dist/${Stack}/${Stage}/podcasts-rss/podcasts-rss-0.1.0-SNAPSHOT.tgz .
 
-            tar -xvf podcasts-rss-0.1-SNAPSHOT.tgz
-            rm podcasts-rss-0.1-SNAPSHOT.tgz
-            mv podcasts-rss-0.1-SNAPSHOT podcasts-rss
+            tar -xvf podcasts-rss-0.1.0-SNAPSHOT.tgz
+            rm podcasts-rss-0.1.0-SNAPSHOT.tgz
+            mv podcasts-rss-0.1.0-SNAPSHOT podcasts-rss
 
             chown -R content-api /home/content-api /etc/gu
             chgrp -R content-api /home/content-api /etc/gu


### PR DESCRIPTION
For some reason, sbt will generate an artefact with a suffix like `-<version>-SNAPSOT` in the name. We've noticed that because the last merge failed to update in PROD. After looking into the S3 folder with riff-raff artefacts, we noticed the presence of two files:

- one with `0.1-SNAPSHOT` from last December
- one with `0.1.0-SNAPSHOT` from today

of course the cloudformation launch config uses the former.

It would probably be best to leave the version name out completely...