### PR TITLE
Add SmartNews-specific elements

### DIFF
--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -22,7 +22,7 @@ object iTunesRssFeed {
 
     tag.podcast match {
       case Some(podcast) => Good {
-        <rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
+        <rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:media="http://search.yahoo.com/mrss/" xmlns:snf="http://www.smartnews.be/snf" version="2.0">
           <channel>
             <itunes:new-feed-url>{ s"${tag.webUrl}/podcast.xml" }</itunes:new-feed-url>
             <title>{ tag.webTitle }</title>
@@ -33,6 +33,12 @@ object iTunesRssFeed {
             <lastBuildDate>
               { DateSupport.toRssTimeFormat(DateTime.now) }
             </lastBuildDate>
+            <pubDate>
+              { DateSupport.toRssTimeFormat(DateTime.now) }
+            </pubDate>
+            <snf:logo>
+              <url>https://i.guim.co.uk/img/media/34715756efe2e3da06e30801edb9d03a1c9ab8df/226_0_2223_1334/master/2223.jpg?width=220&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2&amp;s=5e01a897c857dc33979cd7fc75fdcf56</url>
+            </snf:logo>
             <ttl>15</ttl>
             {
               podcast.podcastType match {

--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -20,6 +20,8 @@ object iTunesRssFeed {
 
     val author = if (tag.id == "society/series/token" || tag.id == "books/series/books") "The Guardian" else "theguardian.com"
 
+    val pubDate = DateSupport.toRssTimeFormat(DateTime.now)
+
     tag.podcast match {
       case Some(podcast) => Good {
         <rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:media="http://search.yahoo.com/mrss/" xmlns:snf="http://www.smartnews.be/snf" version="2.0">
@@ -30,12 +32,8 @@ object iTunesRssFeed {
             <description>{ description }</description>
             <language>en-gb</language>
             <copyright>{ podcast.copyright }</copyright>
-            <lastBuildDate>
-              { DateSupport.toRssTimeFormat(DateTime.now) }
-            </lastBuildDate>
-            <pubDate>
-              { DateSupport.toRssTimeFormat(DateTime.now) }
-            </pubDate>
+            <lastBuildDate>{ pubDate }</lastBuildDate>
+            <pubDate>{ pubDate }</pubDate>
             <snf:logo>
               <url>https://i.guim.co.uk/img/media/34715756efe2e3da06e30801edb9d03a1c9ab8df/226_0_2223_1334/master/2223.jpg?width=220&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2&amp;s=5e01a897c857dc33979cd7fc75fdcf56</url>
             </snf:logo>

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -96,9 +96,8 @@ class iTunesRssItem(val podcast: Content, val tagId: String, author: String, ass
     val capiUrl = asset.file.getOrElse("")
     val regex = s"""https?://static(-secure)?.guim.co.uk/audio/kip/$tagId"""
     val guid = {
-      val launchDay = new DateTime(2018, 11, 14, 0, 0)
       val default = capiUrl.replaceAll(regex, "http://download.guardian.co.uk/draft/audio")
-      if (lastModified.isAfter(launchDay))
+      if (lastModified.isAfter(iTunesRssItem.guuidLaunchDay))
         podcast.fields.flatMap(_.internalComposerCode).getOrElse(default)
       else
         default
@@ -122,6 +121,8 @@ class iTunesRssItem(val podcast: Content, val tagId: String, author: String, ass
 
     val summary = Filtering.standfirst(standfirstOrTrail.getOrElse("")) + membershipCta
 
+    val body = podcast.fields.flatMap(_.body).getOrElse("")
+
     <item>
       <title> { title } </title>
       <description> { description } </description>
@@ -139,6 +140,19 @@ class iTunesRssItem(val podcast: Content, val tagId: String, author: String, ass
       <itunes:keywords>{ keywords }</itunes:keywords>
       <itunes:subtitle>{ subtitle }</itunes:subtitle>
       <itunes:summary>{ scala.xml.Utility.escape(summary) }</itunes:summary>
+      <content:encoded>{ body }</content:encoded>
+      <snf:advertisement>
+        <snf:adcontent>
+          <![CDATA[  
+          <script src='https://www.googletagservices.com/tag/js/gpt.js'>
+            googletag.pubads().definePassback('/59666047/smartnews', [300, 250]).display();
+          </script>
+          ]]>
+        </snf:adcontent>
+      </snf:advertisement>
+      <snf:analytics><![CDATA[
+        <script type="text/javascript" charset="utf8" src="https://j.ophan.co.uk/smart-news.js"></script>
+      ]]></snf:analytics>
     </item>
   }
 
@@ -157,4 +171,10 @@ class iTunesRssItem(val podcast: Content, val tagId: String, author: String, ass
     val keys = for (t <- tags) yield t.webTitle
     keys.mkString(", ")
   }
+}
+
+object iTunesRssItem {
+
+  val guuidLaunchDay = new DateTime(2018, 11, 14, 0, 0)
+
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -34,6 +34,7 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
     val client = new CustomCapiClient(apiKey)
 
     val query = ItemQuery(tagId)
+      .rights("syndicatable")
       .showElements("audio")
       .showTags("keyword")
       .showFields("all")


### PR DESCRIPTION
Provides enhancements to the podcast feeds so that they validate agains the SmartNews specification, for integration in that platform.

TODO:

- [ ] Upload logo somewhere
- [ ] Sanitise body
- [ ] Fix Ophan script to account for specific item
- [ ] Add tests
- [ ] Validate against iTunes (make sure new elements don't break anything)
- [ ] Validate against SmartNews
