### PR TITLE
Add CTAs for the moment

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -18,18 +18,46 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset) {
     val pubDate = DateSupport.toRssTimeFormat(lastModified)
 
     val membershipCta = {
+      val theMomentFrom = new DateTime(2019, 2, 20, 0, 0)
       val launchDayTIF = new DateTime(2018, 11, 14, 0, 0)
       val launchDayPW = new DateTime(2016, 12, 6, 0, 0)
       val launchDayPWNew = new DateTime(2018, 11, 15, 0, 0)
       if (tagId == "politics/series/politicsweekly") {
-        if (lastModified.isAfter(launchDayPWNew))
+        if (lastModified.isAfter(theMomentFrom))
+          """. Help support our independent journalism at <a href="https://gu.com/politicspod">gu.com/politicspod</a>"""
+        else if (lastModified.isAfter(launchDayPWNew))
           """. To support The Guardian’s independent journalism, visit <a href="https://gu.com/give/podcast">gu.com/give/podcast</a>"""
         else if (lastModified.isAfter(launchDayPW))
           """. Please support our work and help us keep the world informed. To fund us, go to https://gu.com/give/podcast"""
         else
           ""
-      } else if (tagId == "news/series/todayinfocus" && lastModified.isAfter(launchDayTIF)) {
-        """. To support The Guardian’s independent journalism, visit <a href="https://gu.com/todayinfocus/support">gu.com/todayinfocus/support</a>"""
+      } else if (tagId == "news/series/todayinfocus") {
+        if (lastModified.isAfter(theMomentFrom))
+          """. Help support our independent journalism at <a href="https://gu.com/infocus">gu.com/infocus</a>"""
+        else if (lastModified.isAfter(launchDayTIF))
+          """. To support The Guardian’s independent journalism, visit <a href="https://gu.com/todayinfocus/support">gu.com/todayinfocus/support</a>"""
+        else
+          ""
+      } else if (tagId == "books/series/books") {
+        if (lastModified.isAfter(theMomentFrom))
+          """. Help support our independent journalism at <a href="https://gu.com/bookspod">gu.com/bookspod</a>"""
+        else
+          ""
+      } else if (tagId == "news/series/the-audio-long-read") {        
+        if (lastModified.isAfter(theMomentFrom))
+          """. Help support our independent journalism at <a href="https://gu.com/longreadpod">gu.com/longreadpod</a>"""
+        else
+          ""
+      } else if (tagId == "science/series/science") {
+        if (lastModified.isAfter(theMomentFrom))
+          """. Help support our independent journalism at <a href="https://gu.com/sciencepod">gu.com/sciencepod</a>"""
+        else
+          ""
+      } else if (tagId == "technology/series/chips-with-everything") {
+        if (lastModified.isAfter(theMomentFrom))
+          """. Help support our independent journalism at <a href="https://gu.com/chipspod">gu.com/chipspod</a>"""
+        else
+          ""
       } else {
         ""
       }


### PR DESCRIPTION
Adds a few more ctas to other podcasts and overrides the existing ones for future episodes.

_nb_: there is no expiry date, as the pages will still be up after the campaign