### PR TITLE
Remove usage of deprecated gu.com domain

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -24,38 +24,38 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset) {
       val launchDayPWNew = new DateTime(2018, 11, 15, 0, 0)
       if (tagId == "politics/series/politicsweekly") {
         if (lastModified.isAfter(theMomentFrom))
-          """. Help support our independent journalism at <a href="https://gu.com/politicspod">gu.com/politicspod</a>"""
+          """. Help support our independent journalism at <a href="https://www.theguardian.com/politicspod">theguardian.com/politicspod</a>"""
         else if (lastModified.isAfter(launchDayPWNew))
-          """. To support The Guardian’s independent journalism, visit <a href="https://gu.com/give/podcast">gu.com/give/podcast</a>"""
+          """. To support The Guardian’s independent journalism, visit <a href="https://www.theguardian.com/give/podcast">theguardian.com/give/podcast</a>"""
         else if (lastModified.isAfter(launchDayPW))
-          """. Please support our work and help us keep the world informed. To fund us, go to https://gu.com/give/podcast"""
+          """. Please support our work and help us keep the world informed. To fund us, go to https://www.theguardian.com/give/podcast"""
         else
           ""
       } else if (tagId == "news/series/todayinfocus") {
         if (lastModified.isAfter(theMomentFrom))
-          """. Help support our independent journalism at <a href="https://gu.com/infocus">gu.com/infocus</a>"""
+          """. Help support our independent journalism at <a href="https://www.theguardian.com/infocus">theguardian.com/infocus</a>"""
         else if (lastModified.isAfter(launchDayTIF))
-          """. To support The Guardian’s independent journalism, visit <a href="https://gu.com/todayinfocus/support">gu.com/todayinfocus/support</a>"""
+          """. To support The Guardian’s independent journalism, visit <a href="https://www.theguardian.com/todayinfocus/support">theguardian.com/todayinfocus/support</a>"""
         else
           ""
       } else if (tagId == "books/series/books") {
         if (lastModified.isAfter(theMomentFrom))
-          """. Help support our independent journalism at <a href="https://gu.com/bookspod">gu.com/bookspod</a>"""
+          """. Help support our independent journalism at <a href="https://www.theguardian.com/bookspod">theguardian.com/bookspod</a>"""
         else
           ""
       } else if (tagId == "news/series/the-audio-long-read") {        
         if (lastModified.isAfter(theMomentFrom))
-          """. Help support our independent journalism at <a href="https://gu.com/longreadpod">gu.com/longreadpod</a>"""
+          """. Help support our independent journalism at <a href="https://www.theguardian.com/longreadpod">theguardian.com/longreadpod</a>"""
         else
           ""
       } else if (tagId == "science/series/science") {
         if (lastModified.isAfter(theMomentFrom))
-          """. Help support our independent journalism at <a href="https://gu.com/sciencepod">gu.com/sciencepod</a>"""
+          """. Help support our independent journalism at <a href="https://www.theguardian.com/sciencepod">theguardian.com/sciencepod</a>"""
         else
           ""
       } else if (tagId == "technology/series/chips-with-everything") {
         if (lastModified.isAfter(theMomentFrom))
-          """. Help support our independent journalism at <a href="https://gu.com/chipspod">gu.com/chipspod</a>"""
+          """. Help support our independent journalism at <a href="https://www.theguardian.com/chipspod">theguardian.com/chipspod</a>"""
         else
           ""
       } else {


### PR DESCRIPTION
The usage of `gu.com` should be avoided as it slow down access to content for user due to an additional network redirection.

**Background**

We introduced `gu.com` domain for short urls when social networks where including `url` in character counts and therefore it was extremely useful have shorter possible urls. This is no more case, but `gu.com` remains useful on print where number of chars can be very limited.  

**Technical impact of using `gu.com`**

When accessing a `gu.com/bookspod` URL the following connections happen:

- connection to `gu.com/bookspod` redirected to `www.theguardian.com/bookspod`
- connection to `www.theguardian.com/bookspod` redirected  to `support.theguardian.com/contribute?...`
- connection to `support.theguardian.com/contribute?...` redirected to `support.theguardian.com/uk/contribute?...`

On a slow mobile connection (3G) the price for each redirect is `2 seconds`! 

<img width="1493" alt="screenshot 2019-02-27 at 11 41 25" src="https://user-images.githubusercontent.com/615085/53488259-b1d37f00-3a85-11e9-8525-c078d73220ff.png">

According to [Greg Linden](http://glinden.blogspot.com/2006/11/marissa-mayer-at-web-20.html), about 10 years ago Amazon discovered that every `100ms` of latency was costing them 1% in sales and more recently Google found that `500ms` delay caused a `20%` drop of traffic ( [Source](https://web.archive.org/web/20081117195303/http://home.blarg.net/~glinden/StanfordDataMining.2006-11-29.ppt) ). This may not apply to us with the same scale, but contributions team recent tests show a significant impact of latency in conversion rate (@rjbarbour-g).

Apart from the `2 seconds` penalty on slow connection, `gu.com` domain is not `HSTS` preloaded meaning that the first connection to `gu.com` on a web browser will be on `http`, offering the opportunity for a `man-in-the-middle` type of attack allowing an attacker to redirect to a fake contributions page.   
 
**Other considerations**

Some urls seems to be broken, I have not updated them

- https://www.theguardian.com/politicspod
- https://www.theguardu.com/give/podcast

