### PR TITLE
Increase number of podcasts requested from 100 to 200

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -37,7 +37,7 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
       .showElements("audio")
       .showTags("keyword")
       .showFields("all")
-      .pageSize(100) // number of podcasts to be served
+      .pageSize(200) // number of podcasts to be served (max single request page size)
 
     client.getResponse(query) map { itemResponse =>
       itemResponse.status match {


### PR DESCRIPTION
I _think_ this is all that's needed to fetch up to 200 podcasts in a single bound
