### PR TITLE
Strip ' – podcast' from title

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -47,7 +47,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset) {
           """. Help support our independent journalism at <a href="https://www.theguardian.com/bookspod">theguardian.com/bookspod</a>"""
         else
           ""
-      } else if (tagId == "news/series/the-audio-long-read") {        
+      } else if (tagId == "news/series/the-audio-long-read") {
         if (lastModified.isAfter(theMomentFrom))
           """. Help support our independent journalism at <a href="https://www.theguardian.com/longreadpod">theguardian.com/longreadpod</a>"""
         else

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -11,7 +11,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset) {
 
   def toXml: Node = {
 
-    val title = podcast.webTitle.stripSuffix(" – podcast")
+    val title = podcast.webTitle.stripSuffix(" – podcast").stripSuffix(" | podcast")
 
     val lastModified = podcast.webPublicationDate.map(date => new DateTime(date.dateTime)).getOrElse(DateTime.now)
 

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -11,7 +11,9 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset) {
 
   def toXml: Node = {
 
-    val title = podcast.webTitle.stripSuffix(" – podcast").stripSuffix(" | podcast")
+    // TODO: remove the below when suffix is added only where it is needed, and not by journalists
+    val suffix = """(.*) [-–|] podcast$""".r
+    val title = podcast.webTitle match { case suffix(prefix) => prefix; case otherwise => otherwise }
 
     val lastModified = podcast.webPublicationDate.map(date => new DateTime(date.dateTime)).getOrElse(DateTime.now)
 

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -11,7 +11,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset) {
 
   def toXml: Node = {
 
-    val title = podcast.webTitle
+    val title = podcast.webTitle.stripSuffix(" – podcast")
 
     val lastModified = podcast.webPublicationDate.map(date => new DateTime(date.dateTime)).getOrElse(DateTime.now)
 

--- a/test/com/gu/ItunesRssItemSpec.scala
+++ b/test/com/gu/ItunesRssItemSpec.scala
@@ -59,7 +59,7 @@ class ItunesRssItemSpec extends FlatSpec with ItunesTestData with Matchers {
         </itunes:summary>
       </item>
       <item>
-        <title>The story of our brains - podcast</title>
+        <title>The story of our brains</title>
         <description>
           Neuroscientist David Eagleman discusses how neuroscience and technology are reshaping how we understand our brains
         </description>

--- a/test/com/gu/ItunesRssItemSpec.scala
+++ b/test/com/gu/ItunesRssItemSpec.scala
@@ -17,7 +17,7 @@ class ItunesRssItemSpec extends FlatSpec with ItunesTestData with Matchers {
     val expectedXml = RemoveWhitespace.transform(
       <item>
         <title>
-          Inside the mind of renowned mathematician John Conway - podcast
+          Inside the mind of renowned mathematician John Conway
         </title>
         <description>
           John Conway sheds light on the true nature of numbers, the beauty lying within maths and why game-playing is so important to mathematical discovery


### PR DESCRIPTION
This is added for `SEO` purpose and can be safely removed in RSS

```xml
<item>
<title>
From bootcamp to burnout: how to make it as a YouTuber – podcast
</title>
<description>
Young stars on the Google-owned site can become multi-millionaires almost overnight but controversy has stalked every stage of YouTube’s growth. Plus: Amelia Abraham on rising LGBT hate crimes. Help support our independent journalism at <a href="https://www.theguardian.com/infocus">theguardian.com/infocus</a>
</description>
<enclosure url="https://flex.acast.com/audio.guim.co.uk/2019/06/14-62682-190617_TIF_youtube3.mp3" length="32271338" type="audio/mpeg"/>
<pubDate>Mon, 17 Jun 2019 02:00:06 GMT</pubDate>
<guid>5d0379028f08faa5870543b9</guid>
<itunes:duration>00:26:50</itunes:duration>
<itunes:author>The Guardian</itunes:author>
<itunes:explicit>clean</itunes:explicit>
<itunes:keywords>
YouTube, Technology, Google, Video on demand, Media
</itunes:keywords>
<itunes:subtitle>
Young stars on the Google-owned site can become multi-millionaires almost overnight but controversy has stalked every stage of YouTube’s growth. Plus: Amelia Abraham on rising LGBT hate crimes
</itunes:subtitle>
<itunes:summary>
Young stars on the Google-owned site can become multi-millionaires almost overnight but controversy has stalked every stage of YouTube’s growth. Plus: Amelia Abraham on rising LGBT hate crimes. Help support our independent journalism at &lt;a href=&quot;https://www.theguardian.com/infocus&quot;&gt;theguardian.com/infocus&lt;/a&gt;
</itunes:summary>
</item>
<item>
```