### PR TITLE
Apply fixed Acast path for the gene gap podcast

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -119,7 +119,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset) {
         AcastLaunchGroup(new DateTime(2019, 10, 7, 0, 0), Seq(
           "australia-news/series/full-story")),
         AcastLaunchGroup(new DateTime(2020, 1, 28, 0, 0), Seq(
-          "science/series/thegenegapcommonsthreads")))
+          "science/series/thegenegapcommonthreads")))
       val useAcastProxy: Boolean = acastPodcasts.find(_.tagIds.contains(tagId)).exists(p => lastModified.isAfter(p.launchDate))
       if (useAcastProxy) "https://flex.acast.com/" + url.replace("https://", "") else url
 


### PR DESCRIPTION
Following on from https://github.com/guardian/itunes-rss/pull/80, this PR applies a fix to use the correct path for Acast.
