### PR TITLE
Adding cloudformation to support wazuh agent

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -47,7 +47,7 @@ Resources:
           - cloudformation:DescribeStackResource
           Resource: "*"
       Roles:
-      - Ref: RootRole
+      - !Ref: RootRole
   DownloadConfigFromS3Policy:
     Type: AWS::IAM::Policy
     Properties:
@@ -61,7 +61,7 @@ Resources:
           - arn:aws:s3:::content-api-config/*
           - arn:aws:s3:::content-api-dist/*
       Roles:
-      - Ref: RootRole
+      - !Ref: RootRole
   CloudwatchPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -103,15 +103,15 @@ Resources:
     Properties:
       Path: "/"
       Roles:
-      - Ref: RootRole
+      - !Ref: RootRole
   LoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
       Scheme: internet-facing
       SecurityGroups:
-      - Ref: LoadBalancerSecurityGroup
+      - !Ref: LoadBalancerSecurityGroup
       Subnets:
-        Ref: Subnets
+        !Ref: Subnets
       CrossZone: true
       Listeners:
       - Protocol: HTTP
@@ -127,26 +127,26 @@ Resources:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
       VPCZoneIdentifier:
-        Ref: Subnets
+        !Ref: Subnets
       AvailabilityZones:
         Fn::GetAZs: ''
       LaunchConfigurationName:
-        Ref: LaunchConfig
+        !Ref: LaunchConfig
       MinSize: '1'
       MaxSize: '20'
       DesiredCapacity: '1'
       HealthCheckType: ELB
       HealthCheckGracePeriod: 300
       LoadBalancerNames:
-      - Ref: LoadBalancer
+      - !Ref: LoadBalancer
       Tags:
       - Key: Stage
         Value:
-          Ref: Stage
+          !Ref: Stage
         PropagateAtLaunch: 'true'
       - Key: Stack
         Value:
-          Ref: Stack
+          !Ref: Stack
         PropagateAtLaunch: 'true'
       - Key: App
         Value: podcasts-rss
@@ -155,7 +155,7 @@ Resources:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties:
       AutoScalingGroupName:
-        Ref: AutoscalingGroup
+        !Ref: AutoscalingGroup
       AdjustmentType: PercentChangeInCapacity
       ScalingAdjustment: '100'
       Cooldown: '60'
@@ -163,7 +163,7 @@ Resources:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties:
       AutoScalingGroupName:
-        Ref: AutoscalingGroup
+        !Ref: AutoscalingGroup
       AdjustmentType: ChangeInCapacity
       ScalingAdjustment: "-1"
       Cooldown: '600'
@@ -175,14 +175,14 @@ Resources:
       Statistic: Average
       Threshold: '10'
       AlarmActions:
-      - Ref: ScaleUpPolicy
+      - !Ref: ScaleUpPolicy
       OKActions:
-      - Ref: ScaleDownPolicy
+      - !Ref: ScaleDownPolicy
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
       - Name: AutoScalingGroupName
         Value:
-          Ref: AutoscalingGroup
+          !Ref: AutoscalingGroup
       MetricName: CPUUtilization
       Namespace: AWS/EC2
       Period: '60'
@@ -207,14 +207,14 @@ Resources:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
       ImageId:
-        Ref: AMI
+        !Ref: AMI
       AssociatePublicIpAddress: true
       SecurityGroups:
-      - Ref: ApplicationSecurityGroup
-      - Ref: WazuhSecurityGroup
+      - !Ref: ApplicationSecurityGroup
+      - !Ref: WazuhSecurityGroup
       InstanceType: t3.small
       IamInstanceProfile:
-        Ref: InstanceProfile
+        !Ref: InstanceProfile
       UserData:
         Fn::Base64:
           !Sub |
@@ -242,7 +242,7 @@ Resources:
     Properties:
       GroupDescription: Public access to the load balancer on port 80
       VpcId:
-        Ref: VPC
+        !Ref: VPC
       SecurityGroupIngress:
       - IpProtocol: tcp
         FromPort: '80'
@@ -258,7 +258,7 @@ Resources:
     Properties:
       GroupDescription: SSH and HTTP
       VpcId:
-        Ref: VPC
+        !Ref: VPC
       SecurityGroupIngress:
       - IpProtocol: tcp
         FromPort: '9000'
@@ -268,7 +268,7 @@ Resources:
         FromPort: '9000'
         ToPort: '9000'
         SourceSecurityGroupId:
-          Ref: LoadBalancerSecurityGroup
+          !Ref: LoadBalancerSecurityGroup
       - IpProtocol: tcp
         FromPort: '22'
         ToPort: '22'

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -74,6 +74,30 @@ Resources:
           Resource: '*'
       Roles:
       - !Ref RootRole
+  DescribeInstancesPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: ec2:DescribeInstances
+            Effect: Allow
+            Resource: '*'
+      PolicyName: ec2-describe-instances
+      Roles:
+        - !Ref RootRole
+  Ec2DescribeAutoScalingGroupsPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: ec2-describe-autoscaling-groups
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action:
+              - autoscaling:DescribeAutoScalingGroups
+              - autoscaling:DescribeAutoScalingInstances
+            Resource: "*"
+      Roles:
+        - Ref RootRole
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
@@ -187,6 +211,7 @@ Resources:
       AssociatePublicIpAddress: true
       SecurityGroups:
       - Ref: ApplicationSecurityGroup
+      - Ref: WazuhSecurityGroup
       InstanceType: t3.small
       IamInstanceProfile:
         Ref: InstanceProfile
@@ -248,6 +273,17 @@ Resources:
         FromPort: '22'
         ToPort: '22'
         CidrIp: 77.91.248.0/21
+  WazuhSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow outbound traffic from wazuh agent to manager
+      VpcId:
+        !Ref VPC
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 1514
+          ToPort: 1515
+          CidrIp: 0.0.0.0/0
 Outputs:
   LoadBalancer:
     Value:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -47,7 +47,7 @@ Resources:
           - cloudformation:DescribeStackResource
           Resource: "*"
       Roles:
-      - !Ref: RootRole
+      - Ref: RootRole
   DownloadConfigFromS3Policy:
     Type: AWS::IAM::Policy
     Properties:
@@ -61,7 +61,7 @@ Resources:
           - arn:aws:s3:::content-api-config/*
           - arn:aws:s3:::content-api-dist/*
       Roles:
-      - !Ref: RootRole
+      - Ref: RootRole
   CloudwatchPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -97,21 +97,21 @@ Resources:
               - autoscaling:DescribeAutoScalingInstances
             Resource: "*"
       Roles:
-        - Ref RootRole
+        - !Ref RootRole
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: "/"
       Roles:
-      - !Ref: RootRole
+      - Ref: RootRole
   LoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
       Scheme: internet-facing
       SecurityGroups:
-      - !Ref: LoadBalancerSecurityGroup
+      - Ref: LoadBalancerSecurityGroup
       Subnets:
-        !Ref: Subnets
+        Ref: Subnets
       CrossZone: true
       Listeners:
       - Protocol: HTTP
@@ -127,26 +127,26 @@ Resources:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
       VPCZoneIdentifier:
-        !Ref: Subnets
+        Ref: Subnets
       AvailabilityZones:
         Fn::GetAZs: ''
       LaunchConfigurationName:
-        !Ref: LaunchConfig
+        Ref: LaunchConfig
       MinSize: '1'
       MaxSize: '20'
       DesiredCapacity: '1'
       HealthCheckType: ELB
       HealthCheckGracePeriod: 300
       LoadBalancerNames:
-      - !Ref: LoadBalancer
+      - Ref: LoadBalancer
       Tags:
       - Key: Stage
         Value:
-          !Ref: Stage
+          Ref: Stage
         PropagateAtLaunch: 'true'
       - Key: Stack
         Value:
-          !Ref: Stack
+          Ref: Stack
         PropagateAtLaunch: 'true'
       - Key: App
         Value: podcasts-rss
@@ -155,7 +155,7 @@ Resources:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties:
       AutoScalingGroupName:
-        !Ref: AutoscalingGroup
+        Ref: AutoscalingGroup
       AdjustmentType: PercentChangeInCapacity
       ScalingAdjustment: '100'
       Cooldown: '60'
@@ -163,7 +163,7 @@ Resources:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties:
       AutoScalingGroupName:
-        !Ref: AutoscalingGroup
+        Ref: AutoscalingGroup
       AdjustmentType: ChangeInCapacity
       ScalingAdjustment: "-1"
       Cooldown: '600'
@@ -175,14 +175,14 @@ Resources:
       Statistic: Average
       Threshold: '10'
       AlarmActions:
-      - !Ref: ScaleUpPolicy
+      - Ref: ScaleUpPolicy
       OKActions:
-      - !Ref: ScaleDownPolicy
+      - Ref: ScaleDownPolicy
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
       - Name: AutoScalingGroupName
         Value:
-          !Ref: AutoscalingGroup
+          Ref: AutoscalingGroup
       MetricName: CPUUtilization
       Namespace: AWS/EC2
       Period: '60'
@@ -207,14 +207,14 @@ Resources:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
       ImageId:
-        !Ref: AMI
+        Ref: AMI
       AssociatePublicIpAddress: true
       SecurityGroups:
-      - !Ref: ApplicationSecurityGroup
-      - !Ref: WazuhSecurityGroup
+      - Ref: ApplicationSecurityGroup
+      - Ref: WazuhSecurityGroup
       InstanceType: t3.small
       IamInstanceProfile:
-        !Ref: InstanceProfile
+        Ref: InstanceProfile
       UserData:
         Fn::Base64:
           !Sub |
@@ -242,7 +242,7 @@ Resources:
     Properties:
       GroupDescription: Public access to the load balancer on port 80
       VpcId:
-        !Ref: VPC
+        Ref: VPC
       SecurityGroupIngress:
       - IpProtocol: tcp
         FromPort: '80'
@@ -258,7 +258,7 @@ Resources:
     Properties:
       GroupDescription: SSH and HTTP
       VpcId:
-        !Ref: VPC
+        Ref: VPC
       SecurityGroupIngress:
       - IpProtocol: tcp
         FromPort: '9000'
@@ -268,7 +268,7 @@ Resources:
         FromPort: '9000'
         ToPort: '9000'
         SourceSecurityGroupId:
-          !Ref: LoadBalancerSecurityGroup
+          Ref: LoadBalancerSecurityGroup
       - IpProtocol: tcp
         FromPort: '22'
         ToPort: '22'

--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -14,7 +14,7 @@ deployments:
     app: podcasts-rss
     parameters:
       amiTags:
-        Recipe: ubuntu-xenial-java8
+        Recipe: ubuntu-bionic-capi
         AmigoStage: PROD
       amiEncrypted: true
 


### PR DESCRIPTION
This PR makes some changes to the security configuration of the launch config for the apps auto scale group.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This is to support enabling the Wazuh vulnerability scanner agent. For more details see:

https://github.com/guardian/security-hq/blob/main/hq/markdown/wazuh.md

The changes to the security config are as follows:

- Adding a security group to allow network connections from the agent to the Wazuh service.
- Allowing read permissions on the autoscale group to allow the wazuh agent to collect information about the ASG.

NOTE: In addition to these changes we need to update the AMI configured in the itunes-rss launch configuration to an AMI that has the Wazuh profile:

https://amigo.gutools.co.uk/recipes/ubuntu-bionic-capi

This is configured manually in the stack parameters when deploying the cloudformation template:

<img width="795" alt="Screenshot 2021-04-27 at 14 33 49" src="https://user-images.githubusercontent.com/289928/116250446-a4010d80-a765-11eb-91f9-b1f491693b7f.png">


## How to test

This change should mean the itunes-rss instances show up on the Wazuh dashboard but this is only accessible to the infosec team.

You can see the status of the wazuh agent using the following command:

 ssm cmd -c "service wazuh-agent status | grep Active && journalctl -u wazuh-agent | grep -E \"(Valid|error)\"" -t podcasts-rss,content-api,PROD -p capi
