### PR TITLE
Set ASG min instances to 2 and remove desired value entirely

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -132,9 +132,8 @@ Resources:
         Fn::GetAZs: ''
       LaunchConfigurationName:
         Ref: LaunchConfig
-      MinSize: '1'
+      MinSize: '2'
       MaxSize: '20'
-      DesiredCapacity: '1'
       HealthCheckType: ELB
       HealthCheckGracePeriod: 300
       LoadBalancerNames:


### PR DESCRIPTION
## What does this change?
Reconfigure our cloudformation to specify a minimum of two instances. Whilst I was in there I also removed the desired capacity setting as the ASG should always determine that for itself.

Note that the scale-up policy will still double the cluster capacity
```      
ScaleUpPolicy:
  AdjustmentType: PercentChangeInCapacity
  ScalingAdjustment: '100'
```
and we may choose to rethink that but for now, let's see how it fares.

## How to test
Upload the new CFN. We only have a PROD env so it'll have to go there. Then run a riff-raff deploy and check that there are two instances running.

## How can we measure success?
If we see fewer autoscaling events (ideally none) and fewer 500 errors logged (ideally none) then that's a success.

## Have we considered potential risks?
Risk should be minimal. We're merely changing the minimum number of running instances, something that the ASG has been doing for itself for a long time anyway. If it's running following the CFN update and riff-raff deploy, we ought to be able to assume it's all good.

## Images
N/A

## Accessibility
N/A