### PR TITLE
Add Comfort Eating podcast configuration

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -127,7 +127,9 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset) {
         AcastLaunchGroup(new DateTime(2020, 11, 25, 0, 0), Seq(
           "australia-news/series/temporary")),
         AcastLaunchGroup(new DateTime(2021, 1, 19, 0, 0), Seq(
-          "music/series/reverberate"))
+          "music/series/reverberate")),
+        AcastLaunchGroup(new DateTime(2021, 6, 8, 0, 0), Seq(
+          "lifeandstyle/series/comforteatingwithgracedent"))
       )
 
       val useAcastProxy: Boolean = acastPodcasts.find(_.tagIds.contains(tagId)).exists(p => lastModified.isAfter(p.launchDate))


### PR DESCRIPTION
## What does this change?
Enabling advertising partner Acast for "Comfort Eating" podcast as requested by Max Sanderson

## How to test
Following instructions in this document:
https://docs.google.com/document/d/1A_6eW_Fc11aRQjiOAQ5iLg38XhJisBuVyqY6U1GdwYY/edit

## How can we measure success?
We will test that the podcasts are available and working with ads.
