### PR TITLE
Return 404s not 500s when podcasts or tags are not found

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -4,6 +4,12 @@ import play.api.ApplicationLoader.Context
 import play.api.{ BuiltInComponentsFromContext, NoHttpFiltersComponents }
 import play.api.routing.Router
 import router.Routes
+/* if the import router.Routes above says that it can't resolve router,
+   this article was useful: https://stackoverflow.com/questions/37333140/cannot-import-class-router-routes-in-applicationloader-on-play-2-5
+   tl;dr
+   1. Make sure your build.sbt contains routesGenerator := InjectedRoutesGenerator
+   2. Execute playCompileEverything in sbt and refresh your project in your IDE
+*/
 
 class AppComponents(context: Context)
   extends BuiltInComponentsFromContext(context)

--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -4,6 +4,7 @@ import com.gu.contentapi.client.model.v1.ItemResponse
 import com.gu.contentapi.client.model.v1._
 import org.joda.time.DateTime
 import org.scalactic.{ Bad, Good, Or }
+import play.api.mvc.Results._
 
 import scala.xml.Node
 
@@ -11,12 +12,12 @@ object iTunesRssFeed {
 
   val author = "The Guardian"
 
-  def apply(resp: ItemResponse): Node Or String = resp.tag match {
+  def apply(resp: ItemResponse): Node Or Failed = resp.tag match {
     case Some(t) => toXml(t, resp.results.getOrElse(Nil).toList)
-    case None => Bad("No tag found")
+    case None => Bad(Failed("tag not found", NotFound))
   }
 
-  def toXml(tag: Tag, contents: List[Content]): Node Or String = {
+  def toXml(tag: Tag, contents: List[Content]): Node Or Failed = {
 
     val description = Filtering.description(tag.description.getOrElse(""))
 
@@ -70,7 +71,7 @@ object iTunesRssFeed {
         </rss>
       }
       case None => Bad {
-        "No podcast found"
+        Failed("podcast not found", NotFound)
       }
     }
   }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Future
 
 case class Failed(message: String, status: Status) {
   override val toString: String =
-    s"message: $message, status: ${status.toString}"
+    s"message: $message, status: ${status.header.status}"
 }
 
 class Application(val controllerComponents: ControllerComponents, val config: Configuration) extends BaseController {

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ organization  := "com.gu"
 description   := "podcasts RSS feed"
 scalaVersion  := "2.12.7"
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked")
+routesGenerator := InjectedRoutesGenerator
 
 val root = Project("podcasts-rss", file("."))
   .enablePlugins(PlayScala, RiffRaffArtifact, UniversalPlugin)

--- a/test/com/gu/ItunesRssFeedSpec.scala
+++ b/test/com/gu/ItunesRssFeedSpec.scala
@@ -70,6 +70,7 @@ class ItunesRssFeedSpec extends FlatSpec with ItunesTestData with Matchers {
       case Bad(failed: Failed) =>
         failed.message should be("podcast not found")
         failed.status should be(NotFound)
+        failed.toString should be("message: podcast not found, status: 404")
       case _ =>
         fail("""expected Bad(Failed("podcast not found", NotFound))""")
     }

--- a/test/com/gu/ItunesRssFeedSpec.scala
+++ b/test/com/gu/ItunesRssFeedSpec.scala
@@ -1,8 +1,12 @@
 
 package com.gu.itunes
 
+import org.scalactic.Bad
 import org.scalatest._
+
+import scala.util.{ Failure, Success, Try }
 import scala.xml.Utility.trim
+import play.api.mvc.Results._
 
 class ItunesRssFeedSpec extends FlatSpec with ItunesTestData with Matchers {
 
@@ -59,4 +63,16 @@ class ItunesRssFeedSpec extends FlatSpec with ItunesTestData with Matchers {
     expectedXml \ "channel" \ "image" should be(currentXml \ "channel" \ "image")
     expectedXml \ "channel" \ "category" should be(currentXml \ "channel" \ "category")
   }
+
+  it should "return a 404 if a podcast cannot be found" in {
+    val attempt = Try(iTunesRssFeed(tagMissingPodcastFieldResponse))
+    attempt.get match {
+      case Bad(failed: Failed) =>
+        failed.message should be("podcast not found")
+        failed.status should be(NotFound)
+      case _ =>
+        fail("""expected Bad(Failed("podcast not found", NotFound))""")
+    }
+  }
+
 }

--- a/test/com/gu/ItunesTestData.scala
+++ b/test/com/gu/ItunesTestData.scala
@@ -22,6 +22,11 @@ trait ItunesTestData {
     parseJson[ItemResponse](json)
   }
 
+  val tagMissingPodcastFieldResponse: ItemResponse = {
+    val json = loadJson("itunes-capi-response-no-podcast-tag.json")
+    parseJson[ItemResponse](json)
+  }
+
   // content.guardianapis.com/politics/series/brexit-means?show-fields=all&show-elements=audio&show-tags=keyword&page-size=3
   val itunesCapiResponseAcastTest: ItemResponse = {
     val json = loadJson("itunes-capi-response-acast-test.json")

--- a/test/resources/itunes-capi-response-no-podcast-tag.json
+++ b/test/resources/itunes-capi-response-no-podcast-tag.json
@@ -1,0 +1,2479 @@
+{
+  "response": {
+    "status": "ok",
+    "userTier": "internal",
+    "total": 563,
+    "startIndex": 1,
+    "pageSize": 3,
+    "currentPage": 1,
+    "pages": 188,
+    "orderBy": "newest",
+    "tag": {
+      "id": "football/series/james-richardson-european-newspaper-review",
+      "type": "series",
+      "sectionId": "football",
+      "sectionName": "Football",
+      "webTitle": "James Richardson's European football papers review",
+      "webUrl": "https://www.theguardian.com/football/series/james-richardson-european-newspaper-review",
+      "apiUrl": "https://content.guardianapis.com/football/series/james-richardson-european-newspaper-review",
+      "description": "Football Weekly host James Richardson reviews what the European newspapers are saying about the big Champions League and Europa League matches",
+      "internalName": "James Richardson's European football papers review"
+    },
+    "results": [
+      {
+        "id": "football/video/2014/may/16/beto-hero-turin-james-richardsons-european-football-papers-review-video",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-05-15T22:01:00Z",
+        "webTitle": "Beto, 'The Hero of Turin': James Richardson's European football papers review - video",
+        "webUrl": "https://www.theguardian.com/football/video/2014/may/16/beto-hero-turin-james-richardsons-european-football-papers-review-video",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/may/16/beto-hero-turin-james-richardsons-european-football-papers-review-video",
+        "tags": [
+          {
+            "id": "football/uefa-europa-league",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Europa League",
+            "webUrl": "https://www.theguardian.com/football/uefa-europa-league",
+            "apiUrl": "https://content.guardianapis.com/football/uefa-europa-league",
+            "references": [
+
+            ],
+            "internalName": "Europa League"
+          },
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "football/world-cup-football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "World Cup",
+            "webUrl": "https://www.theguardian.com/football/world-cup-football",
+            "apiUrl": "https://content.guardianapis.com/football/world-cup-football",
+            "references": [
+
+            ],
+            "description": "<p>Coverage of football World Cups from all years.&nbsp;<a href=\"https://www.theguardian.com/football/world-cup-2018\">Go to World Cup 2018.</a></p>",
+            "internalName": "World Cup (football)"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          },
+          {
+            "id": "football/sevilla",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Sevilla",
+            "webUrl": "https://www.theguardian.com/football/sevilla",
+            "apiUrl": "https://content.guardianapis.com/football/sevilla",
+            "references": [
+
+            ],
+            "internalName": "Sevilla (Football club)"
+          },
+          {
+            "id": "football/benfica",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Benfica",
+            "webUrl": "https://www.theguardian.com/football/benfica",
+            "apiUrl": "https://content.guardianapis.com/football/benfica",
+            "references": [
+
+            ],
+            "internalName": "Benfica (Football club)"
+          }
+        ],
+        "elements": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/may/02/james-richardson-european-football-papers-review-video",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-05-01T22:01:00Z",
+        "webTitle": "'A Spanish party in Lisbon': James Richardson's European football papers review – video",
+        "webUrl": "https://www.theguardian.com/football/video/2014/may/02/james-richardson-european-football-papers-review-video",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/may/02/james-richardson-european-football-papers-review-video",
+        "tags": [
+          {
+            "id": "football/championsleague",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Champions League",
+            "webUrl": "https://www.theguardian.com/football/championsleague",
+            "apiUrl": "https://content.guardianapis.com/football/championsleague",
+            "references": [
+
+            ],
+            "internalName": "Champions League"
+          },
+          {
+            "id": "football/atleticomadrid",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Atlético Madrid",
+            "webUrl": "https://www.theguardian.com/football/atleticomadrid",
+            "apiUrl": "https://content.guardianapis.com/football/atleticomadrid",
+            "references": [
+
+            ],
+            "internalName": "Atletico Madrid (Football club)"
+          },
+          {
+            "id": "football/realmadrid",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Real Madrid",
+            "webUrl": "https://www.theguardian.com/football/realmadrid",
+            "apiUrl": "https://content.guardianapis.com/football/realmadrid",
+            "references": [
+
+            ],
+            "internalName": "Real Madrid (Football club)"
+          },
+          {
+            "id": "football/chelsea",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Chelsea",
+            "webUrl": "https://www.theguardian.com/football/chelsea",
+            "apiUrl": "https://content.guardianapis.com/football/chelsea",
+            "references": [
+
+            ],
+            "description": "Read the latest Chelsea news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Chelsea (Football)"
+          },
+          {
+            "id": "football/bayernmunich",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Bayern Munich",
+            "webUrl": "https://www.theguardian.com/football/bayernmunich",
+            "apiUrl": "https://content.guardianapis.com/football/bayernmunich",
+            "references": [
+
+            ],
+            "internalName": "Bayern Munich (Football club)"
+          },
+          {
+            "id": "football/carlo-ancelotti",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Carlo Ancelotti",
+            "webUrl": "https://www.theguardian.com/football/carlo-ancelotti",
+            "apiUrl": "https://content.guardianapis.com/football/carlo-ancelotti",
+            "references": [
+
+            ],
+            "internalName": "Carlo Ancelotti"
+          },
+          {
+            "id": "football/jose-mourinho",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "José Mourinho",
+            "webUrl": "https://www.theguardian.com/football/jose-mourinho",
+            "apiUrl": "https://content.guardianapis.com/football/jose-mourinho",
+            "references": [
+
+            ],
+            "internalName": "Jose Mourinho"
+          },
+          {
+            "id": "football/pep-guardiola",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Pep Guardiola",
+            "webUrl": "https://www.theguardian.com/football/pep-guardiola",
+            "apiUrl": "https://content.guardianapis.com/football/pep-guardiola",
+            "references": [
+
+            ],
+            "internalName": "Pep Guardiola (football)"
+          },
+          {
+            "id": "football/tito-vilanova",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Tito Vilanova",
+            "webUrl": "https://www.theguardian.com/football/tito-vilanova",
+            "apiUrl": "https://content.guardianapis.com/football/tito-vilanova",
+            "references": [
+
+            ],
+            "internalName": "Tito Vilanova"
+          },
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          }
+        ],
+        "elements": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/apr/25/james-richardson-european-football-papers-review-video",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-04-24T22:01:00Z",
+        "webTitle": "Real Madrid's 'golden goal': James Richardson's European football papers review - video",
+        "webUrl": "https://www.theguardian.com/football/video/2014/apr/25/james-richardson-european-football-papers-review-video",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/apr/25/james-richardson-european-football-papers-review-video",
+        "tags": [
+          {
+            "id": "football/championsleague",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Champions League",
+            "webUrl": "https://www.theguardian.com/football/championsleague",
+            "apiUrl": "https://content.guardianapis.com/football/championsleague",
+            "references": [
+
+            ],
+            "internalName": "Champions League"
+          },
+          {
+            "id": "football/realmadrid",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Real Madrid",
+            "webUrl": "https://www.theguardian.com/football/realmadrid",
+            "apiUrl": "https://content.guardianapis.com/football/realmadrid",
+            "references": [
+
+            ],
+            "internalName": "Real Madrid (Football club)"
+          },
+          {
+            "id": "football/bayernmunich",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Bayern Munich",
+            "webUrl": "https://www.theguardian.com/football/bayernmunich",
+            "apiUrl": "https://content.guardianapis.com/football/bayernmunich",
+            "references": [
+
+            ],
+            "internalName": "Bayern Munich (Football club)"
+          },
+          {
+            "id": "football/chelsea",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Chelsea",
+            "webUrl": "https://www.theguardian.com/football/chelsea",
+            "apiUrl": "https://content.guardianapis.com/football/chelsea",
+            "references": [
+
+            ],
+            "description": "Read the latest Chelsea news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Chelsea (Football)"
+          },
+          {
+            "id": "football/atleticomadrid",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Atlético Madrid",
+            "webUrl": "https://www.theguardian.com/football/atleticomadrid",
+            "apiUrl": "https://content.guardianapis.com/football/atleticomadrid",
+            "references": [
+
+            ],
+            "internalName": "Atletico Madrid (Football club)"
+          },
+          {
+            "id": "football/jose-mourinho",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "José Mourinho",
+            "webUrl": "https://www.theguardian.com/football/jose-mourinho",
+            "apiUrl": "https://content.guardianapis.com/football/jose-mourinho",
+            "references": [
+
+            ],
+            "internalName": "Jose Mourinho"
+          },
+          {
+            "id": "football/pep-guardiola",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Pep Guardiola",
+            "webUrl": "https://www.theguardian.com/football/pep-guardiola",
+            "apiUrl": "https://content.guardianapis.com/football/pep-guardiola",
+            "references": [
+
+            ],
+            "internalName": "Pep Guardiola (football)"
+          },
+          {
+            "id": "football/acmilan",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Milan",
+            "webUrl": "https://www.theguardian.com/football/acmilan",
+            "apiUrl": "https://content.guardianapis.com/football/acmilan",
+            "references": [
+
+            ],
+            "internalName": "Milan (AC Milan Football club)"
+          },
+          {
+            "id": "world/silvio-berlusconi",
+            "type": "keyword",
+            "sectionId": "world",
+            "sectionName": "World news",
+            "webTitle": "Silvio Berlusconi",
+            "webUrl": "https://www.theguardian.com/world/silvio-berlusconi",
+            "apiUrl": "https://content.guardianapis.com/world/silvio-berlusconi",
+            "references": [
+
+            ],
+            "internalName": "Silvio Berlusconi"
+          },
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          }
+        ],
+        "elements": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/apr/11/james-richardson-european-football-papers-review-video",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-04-10T22:01:00Z",
+        "webTitle": "'Who is to blame at PSG?' – James Richardson's European football papers video review",
+        "webUrl": "https://www.theguardian.com/football/video/2014/apr/11/james-richardson-european-football-papers-review-video",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/apr/11/james-richardson-european-football-papers-review-video",
+        "tags": [
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          },
+          {
+            "id": "football/barcelona",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Barcelona",
+            "webUrl": "https://www.theguardian.com/football/barcelona",
+            "apiUrl": "https://content.guardianapis.com/football/barcelona",
+            "references": [
+
+            ],
+            "internalName": "Barcelona (Football club)"
+          },
+          {
+            "id": "football/manchester-united",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Manchester United",
+            "webUrl": "https://www.theguardian.com/football/manchester-united",
+            "apiUrl": "https://content.guardianapis.com/football/manchester-united",
+            "references": [
+
+            ],
+            "description": "Read the latest Manchester United news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Manchester United (Football)"
+          },
+          {
+            "id": "football/bayernmunich",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Bayern Munich",
+            "webUrl": "https://www.theguardian.com/football/bayernmunich",
+            "apiUrl": "https://content.guardianapis.com/football/bayernmunich",
+            "references": [
+
+            ],
+            "internalName": "Bayern Munich (Football club)"
+          },
+          {
+            "id": "football/parisstgermain",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Paris Saint-Germain",
+            "webUrl": "https://www.theguardian.com/football/parisstgermain",
+            "apiUrl": "https://content.guardianapis.com/football/parisstgermain",
+            "references": [
+
+            ],
+            "internalName": "Paris Saint-Germain (PSG Football club)"
+          }
+        ],
+        "elements": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/apr/04/james-richardson-european-football-papers-review-video",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-04-03T22:15:00Z",
+        "webTitle": "'The perfect storm for Barcelona' – James Richardson's European football papers video review",
+        "webUrl": "https://www.theguardian.com/football/video/2014/apr/04/james-richardson-european-football-papers-review-video",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/apr/04/james-richardson-european-football-papers-review-video",
+        "tags": [
+          {
+            "id": "football/wayne-rooney",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Wayne Rooney",
+            "webUrl": "https://www.theguardian.com/football/wayne-rooney",
+            "apiUrl": "https://content.guardianapis.com/football/wayne-rooney",
+            "references": [
+
+            ],
+            "internalName": "Wayne Rooney"
+          },
+          {
+            "id": "football/manchester-united",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Manchester United",
+            "webUrl": "https://www.theguardian.com/football/manchester-united",
+            "apiUrl": "https://content.guardianapis.com/football/manchester-united",
+            "references": [
+
+            ],
+            "description": "Read the latest Manchester United news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Manchester United (Football)"
+          },
+          {
+            "id": "football/barcelona",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Barcelona",
+            "webUrl": "https://www.theguardian.com/football/barcelona",
+            "apiUrl": "https://content.guardianapis.com/football/barcelona",
+            "references": [
+
+            ],
+            "internalName": "Barcelona (Football club)"
+          },
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          }
+        ],
+        "elements": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/mar/21/james-richardson-european-football-papers-review-video",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-03-21T00:01:00Z",
+        "webTitle": "'It's your fault, Mancini': James Richardson's European football papers review - video",
+        "webUrl": "https://www.theguardian.com/football/video/2014/mar/21/james-richardson-european-football-papers-review-video",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/mar/21/james-richardson-european-football-papers-review-video",
+        "tags": [
+          {
+            "id": "football/championsleague",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Champions League",
+            "webUrl": "https://www.theguardian.com/football/championsleague",
+            "apiUrl": "https://content.guardianapis.com/football/championsleague",
+            "references": [
+
+            ],
+            "internalName": "Champions League"
+          },
+          {
+            "id": "football/acmilan",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Milan",
+            "webUrl": "https://www.theguardian.com/football/acmilan",
+            "apiUrl": "https://content.guardianapis.com/football/acmilan",
+            "references": [
+
+            ],
+            "internalName": "Milan (AC Milan Football club)"
+          },
+          {
+            "id": "football/galatasaray",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Galatasaray",
+            "webUrl": "https://www.theguardian.com/football/galatasaray",
+            "apiUrl": "https://content.guardianapis.com/football/galatasaray",
+            "references": [
+
+            ],
+            "internalName": "Galatasaray (Football club)"
+          },
+          {
+            "id": "football/roberto-mancini",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Roberto Mancini",
+            "webUrl": "https://www.theguardian.com/football/roberto-mancini",
+            "apiUrl": "https://content.guardianapis.com/football/roberto-mancini",
+            "references": [
+
+            ],
+            "internalName": "Roberto Mancini (football)"
+          },
+          {
+            "id": "football/chelsea",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Chelsea",
+            "webUrl": "https://www.theguardian.com/football/chelsea",
+            "apiUrl": "https://content.guardianapis.com/football/chelsea",
+            "references": [
+
+            ],
+            "description": "Read the latest Chelsea news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Chelsea (Football)"
+          },
+          {
+            "id": "football/manchester-united",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Manchester United",
+            "webUrl": "https://www.theguardian.com/football/manchester-united",
+            "apiUrl": "https://content.guardianapis.com/football/manchester-united",
+            "references": [
+
+            ],
+            "description": "Read the latest Manchester United news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Manchester United (Football)"
+          },
+          {
+            "id": "football/olympiakos",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Olympiakos",
+            "webUrl": "https://www.theguardian.com/football/olympiakos",
+            "apiUrl": "https://content.guardianapis.com/football/olympiakos",
+            "references": [
+
+            ],
+            "internalName": "Olympiakos (Football club)"
+          },
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          }
+        ],
+        "elements": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/mar/14/james-richardson-european-football-papers-review-video",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-03-14T00:01:00Z",
+        "webTitle": "Uli Hoeness: 'one man at Bayern who has trouble putting things in the net' - James Richardson's European football papers video review",
+        "webUrl": "https://www.theguardian.com/football/video/2014/mar/14/james-richardson-european-football-papers-review-video",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/mar/14/james-richardson-european-football-papers-review-video",
+        "tags": [
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "football/bayernmunich",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Bayern Munich",
+            "webUrl": "https://www.theguardian.com/football/bayernmunich",
+            "apiUrl": "https://content.guardianapis.com/football/bayernmunich",
+            "references": [
+
+            ],
+            "internalName": "Bayern Munich (Football club)"
+          },
+          {
+            "id": "football/atleticomadrid",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Atlético Madrid",
+            "webUrl": "https://www.theguardian.com/football/atleticomadrid",
+            "apiUrl": "https://content.guardianapis.com/football/atleticomadrid",
+            "references": [
+
+            ],
+            "internalName": "Atletico Madrid (Football club)"
+          },
+          {
+            "id": "football/acmilan",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Milan",
+            "webUrl": "https://www.theguardian.com/football/acmilan",
+            "apiUrl": "https://content.guardianapis.com/football/acmilan",
+            "references": [
+
+            ],
+            "internalName": "Milan (AC Milan Football club)"
+          },
+          {
+            "id": "football/championsleague",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Champions League",
+            "webUrl": "https://www.theguardian.com/football/championsleague",
+            "apiUrl": "https://content.guardianapis.com/football/championsleague",
+            "references": [
+
+            ],
+            "internalName": "Champions League"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          }
+        ],
+        "elements": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/mar/07/james-richardson-european-football-papers-review-video",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-03-07T00:01:00Z",
+        "webTitle": "'The Özil debate': James Richardson's European football papers review - video",
+        "webUrl": "https://www.theguardian.com/football/video/2014/mar/07/james-richardson-european-football-papers-review-video",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/mar/07/james-richardson-european-football-papers-review-video",
+        "tags": [
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "football/mesut-ozil",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Mesut Ozil",
+            "webUrl": "https://www.theguardian.com/football/mesut-ozil",
+            "apiUrl": "https://content.guardianapis.com/football/mesut-ozil",
+            "references": [
+
+            ],
+            "internalName": "Mesut Ozil"
+          },
+          {
+            "id": "football/ronaldo",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Cristiano Ronaldo",
+            "webUrl": "https://www.theguardian.com/football/ronaldo",
+            "apiUrl": "https://content.guardianapis.com/football/ronaldo",
+            "references": [
+
+            ],
+            "internalName": "Cristiano Ronaldo"
+          },
+          {
+            "id": "football/germany",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Germany",
+            "webUrl": "https://www.theguardian.com/football/germany",
+            "apiUrl": "https://content.guardianapis.com/football/germany",
+            "references": [
+
+            ],
+            "internalName": "Germany football team"
+          },
+          {
+            "id": "football/portugal",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Portugal",
+            "webUrl": "https://www.theguardian.com/football/portugal",
+            "apiUrl": "https://content.guardianapis.com/football/portugal",
+            "references": [
+
+            ],
+            "internalName": "Portugal football team"
+          },
+          {
+            "id": "football/france",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "France",
+            "webUrl": "https://www.theguardian.com/football/france",
+            "apiUrl": "https://content.guardianapis.com/football/france",
+            "references": [
+
+            ],
+            "internalName": "France football team"
+          },
+          {
+            "id": "football/spain",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Spain",
+            "webUrl": "https://www.theguardian.com/football/spain",
+            "apiUrl": "https://content.guardianapis.com/football/spain",
+            "references": [
+
+            ],
+            "internalName": "Spain football team"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          }
+        ],
+        "elements": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/feb/28/james-richardson-european-football-papers-review-video",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-02-28T00:01:00Z",
+        "webTitle": "'Cristiano Ronaldo, return of the giant': James Richardson's European football papers review – video",
+        "webUrl": "https://www.theguardian.com/football/video/2014/feb/28/james-richardson-european-football-papers-review-video",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/feb/28/james-richardson-european-football-papers-review-video",
+        "tags": [
+          {
+            "id": "football/championsleague",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Champions League",
+            "webUrl": "https://www.theguardian.com/football/championsleague",
+            "apiUrl": "https://content.guardianapis.com/football/championsleague",
+            "references": [
+
+            ],
+            "internalName": "Champions League"
+          },
+          {
+            "id": "football/realmadrid",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Real Madrid",
+            "webUrl": "https://www.theguardian.com/football/realmadrid",
+            "apiUrl": "https://content.guardianapis.com/football/realmadrid",
+            "references": [
+
+            ],
+            "internalName": "Real Madrid (Football club)"
+          },
+          {
+            "id": "football/schalke",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Schalke",
+            "webUrl": "https://www.theguardian.com/football/schalke",
+            "apiUrl": "https://content.guardianapis.com/football/schalke",
+            "references": [
+
+            ],
+            "internalName": "Schalke (Football club)"
+          },
+          {
+            "id": "football/olympiakos",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Olympiakos",
+            "webUrl": "https://www.theguardian.com/football/olympiakos",
+            "apiUrl": "https://content.guardianapis.com/football/olympiakos",
+            "references": [
+
+            ],
+            "internalName": "Olympiakos (Football club)"
+          },
+          {
+            "id": "football/manchester-united",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Manchester United",
+            "webUrl": "https://www.theguardian.com/football/manchester-united",
+            "apiUrl": "https://content.guardianapis.com/football/manchester-united",
+            "references": [
+
+            ],
+            "description": "Read the latest Manchester United news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Manchester United (Football)"
+          },
+          {
+            "id": "football/chelsea",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Chelsea",
+            "webUrl": "https://www.theguardian.com/football/chelsea",
+            "apiUrl": "https://content.guardianapis.com/football/chelsea",
+            "references": [
+
+            ],
+            "description": "Read the latest Chelsea news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Chelsea (Football)"
+          },
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          }
+        ],
+        "elements": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/feb/21/raphael-honigsteins-european-football-papers-video-review",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-02-21T00:01:00Z",
+        "webTitle": "'The triumph of Tata': Raphael Honigstein's European football papers review – video",
+        "webUrl": "https://www.theguardian.com/football/video/2014/feb/21/raphael-honigsteins-european-football-papers-video-review",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/feb/21/raphael-honigsteins-european-football-papers-video-review",
+        "tags": [
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "football/championsleague",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Champions League",
+            "webUrl": "https://www.theguardian.com/football/championsleague",
+            "apiUrl": "https://content.guardianapis.com/football/championsleague",
+            "references": [
+
+            ],
+            "internalName": "Champions League"
+          },
+          {
+            "id": "football/acmilan",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Milan",
+            "webUrl": "https://www.theguardian.com/football/acmilan",
+            "apiUrl": "https://content.guardianapis.com/football/acmilan",
+            "references": [
+
+            ],
+            "internalName": "Milan (AC Milan Football club)"
+          },
+          {
+            "id": "football/parisstgermain",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Paris Saint-Germain",
+            "webUrl": "https://www.theguardian.com/football/parisstgermain",
+            "apiUrl": "https://content.guardianapis.com/football/parisstgermain",
+            "references": [
+
+            ],
+            "internalName": "Paris Saint-Germain (PSG Football club)"
+          },
+          {
+            "id": "football/bayerleverkusen",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Bayer Leverkusen",
+            "webUrl": "https://www.theguardian.com/football/bayerleverkusen",
+            "apiUrl": "https://content.guardianapis.com/football/bayerleverkusen",
+            "references": [
+
+            ],
+            "internalName": "Bayer Leverkusen (Football club)"
+          },
+          {
+            "id": "football/bayernmunich",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Bayern Munich",
+            "webUrl": "https://www.theguardian.com/football/bayernmunich",
+            "apiUrl": "https://content.guardianapis.com/football/bayernmunich",
+            "references": [
+
+            ],
+            "internalName": "Bayern Munich (Football club)"
+          },
+          {
+            "id": "football/arsenal",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Arsenal",
+            "webUrl": "https://www.theguardian.com/football/arsenal",
+            "apiUrl": "https://content.guardianapis.com/football/arsenal",
+            "references": [
+
+            ],
+            "description": "Read the latest Arsenal news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Arsenal FC (Football)"
+          },
+          {
+            "id": "football/manchestercity",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Manchester City",
+            "webUrl": "https://www.theguardian.com/football/manchestercity",
+            "apiUrl": "https://content.guardianapis.com/football/manchestercity",
+            "references": [
+
+            ],
+            "description": "Read the latest Manchester City news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Manchester City (Football)"
+          },
+          {
+            "id": "football/barcelona",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Barcelona",
+            "webUrl": "https://www.theguardian.com/football/barcelona",
+            "apiUrl": "https://content.guardianapis.com/football/barcelona",
+            "references": [
+
+            ],
+            "internalName": "Barcelona (Football club)"
+          },
+          {
+            "id": "football/atleticomadrid",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Atlético Madrid",
+            "webUrl": "https://www.theguardian.com/football/atleticomadrid",
+            "apiUrl": "https://content.guardianapis.com/football/atleticomadrid",
+            "references": [
+
+            ],
+            "internalName": "Atletico Madrid (Football club)"
+          },
+          {
+            "id": "football/pep-guardiola",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Pep Guardiola",
+            "webUrl": "https://www.theguardian.com/football/pep-guardiola",
+            "apiUrl": "https://content.guardianapis.com/football/pep-guardiola",
+            "references": [
+
+            ],
+            "internalName": "Pep Guardiola (football)"
+          },
+          {
+            "id": "football/zlatan-ibrahimovic",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Zlatan Ibrahimovic",
+            "webUrl": "https://www.theguardian.com/football/zlatan-ibrahimovic",
+            "apiUrl": "https://content.guardianapis.com/football/zlatan-ibrahimovic",
+            "references": [
+
+            ],
+            "internalName": "Zlatan Ibrahimovic"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          }
+        ],
+        "elements": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      }
+    ],
+    "leadContent": [
+      {
+        "id": "football/video/2014/may/16/beto-hero-turin-james-richardsons-european-football-papers-review-video",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-05-15T22:01:00Z",
+        "webTitle": "Beto, 'The Hero of Turin': James Richardson's European football papers review - video",
+        "webUrl": "https://www.theguardian.com/football/video/2014/may/16/beto-hero-turin-james-richardsons-european-football-papers-review-video",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/may/16/beto-hero-turin-james-richardsons-european-football-papers-review-video",
+        "tags": [
+          {
+            "id": "football/uefa-europa-league",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Europa League",
+            "webUrl": "https://www.theguardian.com/football/uefa-europa-league",
+            "apiUrl": "https://content.guardianapis.com/football/uefa-europa-league",
+            "references": [
+
+            ],
+            "internalName": "Europa League"
+          },
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "football/world-cup-football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "World Cup",
+            "webUrl": "https://www.theguardian.com/football/world-cup-football",
+            "apiUrl": "https://content.guardianapis.com/football/world-cup-football",
+            "references": [
+
+            ],
+            "description": "<p>Coverage of football World Cups from all years.&nbsp;<a href=\"https://www.theguardian.com/football/world-cup-2018\">Go to World Cup 2018.</a></p>",
+            "internalName": "World Cup (football)"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          },
+          {
+            "id": "football/sevilla",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Sevilla",
+            "webUrl": "https://www.theguardian.com/football/sevilla",
+            "apiUrl": "https://content.guardianapis.com/football/sevilla",
+            "references": [
+
+            ],
+            "internalName": "Sevilla (Football club)"
+          },
+          {
+            "id": "football/benfica",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Benfica",
+            "webUrl": "https://www.theguardian.com/football/benfica",
+            "apiUrl": "https://content.guardianapis.com/football/benfica",
+            "references": [
+
+            ],
+            "internalName": "Benfica (Football club)"
+          }
+        ],
+        "elements": [
+
+        ],
+        "references": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/may/02/james-richardson-european-football-papers-review-video",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-05-01T22:01:00Z",
+        "webTitle": "'A Spanish party in Lisbon': James Richardson's European football papers review – video",
+        "webUrl": "https://www.theguardian.com/football/video/2014/may/02/james-richardson-european-football-papers-review-video",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/may/02/james-richardson-european-football-papers-review-video",
+        "tags": [
+          {
+            "id": "football/championsleague",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Champions League",
+            "webUrl": "https://www.theguardian.com/football/championsleague",
+            "apiUrl": "https://content.guardianapis.com/football/championsleague",
+            "references": [
+
+            ],
+            "internalName": "Champions League"
+          },
+          {
+            "id": "football/atleticomadrid",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Atlético Madrid",
+            "webUrl": "https://www.theguardian.com/football/atleticomadrid",
+            "apiUrl": "https://content.guardianapis.com/football/atleticomadrid",
+            "references": [
+
+            ],
+            "internalName": "Atletico Madrid (Football club)"
+          },
+          {
+            "id": "football/realmadrid",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Real Madrid",
+            "webUrl": "https://www.theguardian.com/football/realmadrid",
+            "apiUrl": "https://content.guardianapis.com/football/realmadrid",
+            "references": [
+
+            ],
+            "internalName": "Real Madrid (Football club)"
+          },
+          {
+            "id": "football/chelsea",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Chelsea",
+            "webUrl": "https://www.theguardian.com/football/chelsea",
+            "apiUrl": "https://content.guardianapis.com/football/chelsea",
+            "references": [
+
+            ],
+            "description": "Read the latest Chelsea news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Chelsea (Football)"
+          },
+          {
+            "id": "football/bayernmunich",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Bayern Munich",
+            "webUrl": "https://www.theguardian.com/football/bayernmunich",
+            "apiUrl": "https://content.guardianapis.com/football/bayernmunich",
+            "references": [
+
+            ],
+            "internalName": "Bayern Munich (Football club)"
+          },
+          {
+            "id": "football/carlo-ancelotti",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Carlo Ancelotti",
+            "webUrl": "https://www.theguardian.com/football/carlo-ancelotti",
+            "apiUrl": "https://content.guardianapis.com/football/carlo-ancelotti",
+            "references": [
+
+            ],
+            "internalName": "Carlo Ancelotti"
+          },
+          {
+            "id": "football/jose-mourinho",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "José Mourinho",
+            "webUrl": "https://www.theguardian.com/football/jose-mourinho",
+            "apiUrl": "https://content.guardianapis.com/football/jose-mourinho",
+            "references": [
+
+            ],
+            "internalName": "Jose Mourinho"
+          },
+          {
+            "id": "football/pep-guardiola",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Pep Guardiola",
+            "webUrl": "https://www.theguardian.com/football/pep-guardiola",
+            "apiUrl": "https://content.guardianapis.com/football/pep-guardiola",
+            "references": [
+
+            ],
+            "internalName": "Pep Guardiola (football)"
+          },
+          {
+            "id": "football/tito-vilanova",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Tito Vilanova",
+            "webUrl": "https://www.theguardian.com/football/tito-vilanova",
+            "apiUrl": "https://content.guardianapis.com/football/tito-vilanova",
+            "references": [
+
+            ],
+            "internalName": "Tito Vilanova"
+          },
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          }
+        ],
+        "elements": [
+
+        ],
+        "references": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/apr/11/james-richardson-european-football-papers-review-video",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-04-10T22:01:00Z",
+        "webTitle": "'Who is to blame at PSG?' – James Richardson's European football papers video review",
+        "webUrl": "https://www.theguardian.com/football/video/2014/apr/11/james-richardson-european-football-papers-review-video",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/apr/11/james-richardson-european-football-papers-review-video",
+        "tags": [
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          },
+          {
+            "id": "football/barcelona",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Barcelona",
+            "webUrl": "https://www.theguardian.com/football/barcelona",
+            "apiUrl": "https://content.guardianapis.com/football/barcelona",
+            "references": [
+
+            ],
+            "internalName": "Barcelona (Football club)"
+          },
+          {
+            "id": "football/manchester-united",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Manchester United",
+            "webUrl": "https://www.theguardian.com/football/manchester-united",
+            "apiUrl": "https://content.guardianapis.com/football/manchester-united",
+            "references": [
+
+            ],
+            "description": "Read the latest Manchester United news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Manchester United (Football)"
+          },
+          {
+            "id": "football/bayernmunich",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Bayern Munich",
+            "webUrl": "https://www.theguardian.com/football/bayernmunich",
+            "apiUrl": "https://content.guardianapis.com/football/bayernmunich",
+            "references": [
+
+            ],
+            "internalName": "Bayern Munich (Football club)"
+          },
+          {
+            "id": "football/parisstgermain",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Paris Saint-Germain",
+            "webUrl": "https://www.theguardian.com/football/parisstgermain",
+            "apiUrl": "https://content.guardianapis.com/football/parisstgermain",
+            "references": [
+
+            ],
+            "internalName": "Paris Saint-Germain (PSG Football club)"
+          }
+        ],
+        "elements": [
+
+        ],
+        "references": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/apr/04/james-richardson-european-football-papers-review-video",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-04-03T22:15:00Z",
+        "webTitle": "'The perfect storm for Barcelona' – James Richardson's European football papers video review",
+        "webUrl": "https://www.theguardian.com/football/video/2014/apr/04/james-richardson-european-football-papers-review-video",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/apr/04/james-richardson-european-football-papers-review-video",
+        "tags": [
+          {
+            "id": "football/wayne-rooney",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Wayne Rooney",
+            "webUrl": "https://www.theguardian.com/football/wayne-rooney",
+            "apiUrl": "https://content.guardianapis.com/football/wayne-rooney",
+            "references": [
+
+            ],
+            "internalName": "Wayne Rooney"
+          },
+          {
+            "id": "football/manchester-united",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Manchester United",
+            "webUrl": "https://www.theguardian.com/football/manchester-united",
+            "apiUrl": "https://content.guardianapis.com/football/manchester-united",
+            "references": [
+
+            ],
+            "description": "Read the latest Manchester United news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Manchester United (Football)"
+          },
+          {
+            "id": "football/barcelona",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Barcelona",
+            "webUrl": "https://www.theguardian.com/football/barcelona",
+            "apiUrl": "https://content.guardianapis.com/football/barcelona",
+            "references": [
+
+            ],
+            "internalName": "Barcelona (Football club)"
+          },
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          }
+        ],
+        "elements": [
+
+        ],
+        "references": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/mar/21/james-richardson-european-football-papers-review-video",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-03-21T00:01:00Z",
+        "webTitle": "'It's your fault, Mancini': James Richardson's European football papers review - video",
+        "webUrl": "https://www.theguardian.com/football/video/2014/mar/21/james-richardson-european-football-papers-review-video",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/mar/21/james-richardson-european-football-papers-review-video",
+        "tags": [
+          {
+            "id": "football/championsleague",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Champions League",
+            "webUrl": "https://www.theguardian.com/football/championsleague",
+            "apiUrl": "https://content.guardianapis.com/football/championsleague",
+            "references": [
+
+            ],
+            "internalName": "Champions League"
+          },
+          {
+            "id": "football/acmilan",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Milan",
+            "webUrl": "https://www.theguardian.com/football/acmilan",
+            "apiUrl": "https://content.guardianapis.com/football/acmilan",
+            "references": [
+
+            ],
+            "internalName": "Milan (AC Milan Football club)"
+          },
+          {
+            "id": "football/galatasaray",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Galatasaray",
+            "webUrl": "https://www.theguardian.com/football/galatasaray",
+            "apiUrl": "https://content.guardianapis.com/football/galatasaray",
+            "references": [
+
+            ],
+            "internalName": "Galatasaray (Football club)"
+          },
+          {
+            "id": "football/roberto-mancini",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Roberto Mancini",
+            "webUrl": "https://www.theguardian.com/football/roberto-mancini",
+            "apiUrl": "https://content.guardianapis.com/football/roberto-mancini",
+            "references": [
+
+            ],
+            "internalName": "Roberto Mancini (football)"
+          },
+          {
+            "id": "football/chelsea",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Chelsea",
+            "webUrl": "https://www.theguardian.com/football/chelsea",
+            "apiUrl": "https://content.guardianapis.com/football/chelsea",
+            "references": [
+
+            ],
+            "description": "Read the latest Chelsea news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Chelsea (Football)"
+          },
+          {
+            "id": "football/manchester-united",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Manchester United",
+            "webUrl": "https://www.theguardian.com/football/manchester-united",
+            "apiUrl": "https://content.guardianapis.com/football/manchester-united",
+            "references": [
+
+            ],
+            "description": "Read the latest Manchester United news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Manchester United (Football)"
+          },
+          {
+            "id": "football/olympiakos",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Olympiakos",
+            "webUrl": "https://www.theguardian.com/football/olympiakos",
+            "apiUrl": "https://content.guardianapis.com/football/olympiakos",
+            "references": [
+
+            ],
+            "internalName": "Olympiakos (Football club)"
+          },
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          }
+        ],
+        "elements": [
+
+        ],
+        "references": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/mar/14/james-richardson-european-football-papers-review-video",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-03-14T00:01:00Z",
+        "webTitle": "Uli Hoeness: 'one man at Bayern who has trouble putting things in the net' - James Richardson's European football papers video review",
+        "webUrl": "https://www.theguardian.com/football/video/2014/mar/14/james-richardson-european-football-papers-review-video",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/mar/14/james-richardson-european-football-papers-review-video",
+        "tags": [
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "football/bayernmunich",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Bayern Munich",
+            "webUrl": "https://www.theguardian.com/football/bayernmunich",
+            "apiUrl": "https://content.guardianapis.com/football/bayernmunich",
+            "references": [
+
+            ],
+            "internalName": "Bayern Munich (Football club)"
+          },
+          {
+            "id": "football/atleticomadrid",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Atlético Madrid",
+            "webUrl": "https://www.theguardian.com/football/atleticomadrid",
+            "apiUrl": "https://content.guardianapis.com/football/atleticomadrid",
+            "references": [
+
+            ],
+            "internalName": "Atletico Madrid (Football club)"
+          },
+          {
+            "id": "football/acmilan",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Milan",
+            "webUrl": "https://www.theguardian.com/football/acmilan",
+            "apiUrl": "https://content.guardianapis.com/football/acmilan",
+            "references": [
+
+            ],
+            "internalName": "Milan (AC Milan Football club)"
+          },
+          {
+            "id": "football/championsleague",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Champions League",
+            "webUrl": "https://www.theguardian.com/football/championsleague",
+            "apiUrl": "https://content.guardianapis.com/football/championsleague",
+            "references": [
+
+            ],
+            "internalName": "Champions League"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          }
+        ],
+        "elements": [
+
+        ],
+        "references": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/feb/28/james-richardson-european-football-papers-review-video",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-02-28T00:01:00Z",
+        "webTitle": "'Cristiano Ronaldo, return of the giant': James Richardson's European football papers review – video",
+        "webUrl": "https://www.theguardian.com/football/video/2014/feb/28/james-richardson-european-football-papers-review-video",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/feb/28/james-richardson-european-football-papers-review-video",
+        "tags": [
+          {
+            "id": "football/championsleague",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Champions League",
+            "webUrl": "https://www.theguardian.com/football/championsleague",
+            "apiUrl": "https://content.guardianapis.com/football/championsleague",
+            "references": [
+
+            ],
+            "internalName": "Champions League"
+          },
+          {
+            "id": "football/realmadrid",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Real Madrid",
+            "webUrl": "https://www.theguardian.com/football/realmadrid",
+            "apiUrl": "https://content.guardianapis.com/football/realmadrid",
+            "references": [
+
+            ],
+            "internalName": "Real Madrid (Football club)"
+          },
+          {
+            "id": "football/schalke",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Schalke",
+            "webUrl": "https://www.theguardian.com/football/schalke",
+            "apiUrl": "https://content.guardianapis.com/football/schalke",
+            "references": [
+
+            ],
+            "internalName": "Schalke (Football club)"
+          },
+          {
+            "id": "football/olympiakos",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Olympiakos",
+            "webUrl": "https://www.theguardian.com/football/olympiakos",
+            "apiUrl": "https://content.guardianapis.com/football/olympiakos",
+            "references": [
+
+            ],
+            "internalName": "Olympiakos (Football club)"
+          },
+          {
+            "id": "football/manchester-united",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Manchester United",
+            "webUrl": "https://www.theguardian.com/football/manchester-united",
+            "apiUrl": "https://content.guardianapis.com/football/manchester-united",
+            "references": [
+
+            ],
+            "description": "Read the latest Manchester United news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Manchester United (Football)"
+          },
+          {
+            "id": "football/chelsea",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Chelsea",
+            "webUrl": "https://www.theguardian.com/football/chelsea",
+            "apiUrl": "https://content.guardianapis.com/football/chelsea",
+            "references": [
+
+            ],
+            "description": "Read the latest Chelsea news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Chelsea (Football)"
+          },
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          }
+        ],
+        "elements": [
+
+        ],
+        "references": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/feb/21/raphael-honigsteins-european-football-papers-video-review",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-02-21T00:01:00Z",
+        "webTitle": "'The triumph of Tata': Raphael Honigstein's European football papers review – video",
+        "webUrl": "https://www.theguardian.com/football/video/2014/feb/21/raphael-honigsteins-european-football-papers-video-review",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/feb/21/raphael-honigsteins-european-football-papers-video-review",
+        "tags": [
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "football/championsleague",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Champions League",
+            "webUrl": "https://www.theguardian.com/football/championsleague",
+            "apiUrl": "https://content.guardianapis.com/football/championsleague",
+            "references": [
+
+            ],
+            "internalName": "Champions League"
+          },
+          {
+            "id": "football/acmilan",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Milan",
+            "webUrl": "https://www.theguardian.com/football/acmilan",
+            "apiUrl": "https://content.guardianapis.com/football/acmilan",
+            "references": [
+
+            ],
+            "internalName": "Milan (AC Milan Football club)"
+          },
+          {
+            "id": "football/parisstgermain",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Paris Saint-Germain",
+            "webUrl": "https://www.theguardian.com/football/parisstgermain",
+            "apiUrl": "https://content.guardianapis.com/football/parisstgermain",
+            "references": [
+
+            ],
+            "internalName": "Paris Saint-Germain (PSG Football club)"
+          },
+          {
+            "id": "football/bayerleverkusen",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Bayer Leverkusen",
+            "webUrl": "https://www.theguardian.com/football/bayerleverkusen",
+            "apiUrl": "https://content.guardianapis.com/football/bayerleverkusen",
+            "references": [
+
+            ],
+            "internalName": "Bayer Leverkusen (Football club)"
+          },
+          {
+            "id": "football/bayernmunich",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Bayern Munich",
+            "webUrl": "https://www.theguardian.com/football/bayernmunich",
+            "apiUrl": "https://content.guardianapis.com/football/bayernmunich",
+            "references": [
+
+            ],
+            "internalName": "Bayern Munich (Football club)"
+          },
+          {
+            "id": "football/arsenal",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Arsenal",
+            "webUrl": "https://www.theguardian.com/football/arsenal",
+            "apiUrl": "https://content.guardianapis.com/football/arsenal",
+            "references": [
+
+            ],
+            "description": "Read the latest Arsenal news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Arsenal FC (Football)"
+          },
+          {
+            "id": "football/manchestercity",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Manchester City",
+            "webUrl": "https://www.theguardian.com/football/manchestercity",
+            "apiUrl": "https://content.guardianapis.com/football/manchestercity",
+            "references": [
+
+            ],
+            "description": "Read the latest Manchester City news, transfer rumours, match reports, fixtures and live scores from the Guardian",
+            "internalName": "Manchester City (Football)"
+          },
+          {
+            "id": "football/barcelona",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Barcelona",
+            "webUrl": "https://www.theguardian.com/football/barcelona",
+            "apiUrl": "https://content.guardianapis.com/football/barcelona",
+            "references": [
+
+            ],
+            "internalName": "Barcelona (Football club)"
+          },
+          {
+            "id": "football/atleticomadrid",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Atlético Madrid",
+            "webUrl": "https://www.theguardian.com/football/atleticomadrid",
+            "apiUrl": "https://content.guardianapis.com/football/atleticomadrid",
+            "references": [
+
+            ],
+            "internalName": "Atletico Madrid (Football club)"
+          },
+          {
+            "id": "football/pep-guardiola",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Pep Guardiola",
+            "webUrl": "https://www.theguardian.com/football/pep-guardiola",
+            "apiUrl": "https://content.guardianapis.com/football/pep-guardiola",
+            "references": [
+
+            ],
+            "internalName": "Pep Guardiola (football)"
+          },
+          {
+            "id": "football/zlatan-ibrahimovic",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Zlatan Ibrahimovic",
+            "webUrl": "https://www.theguardian.com/football/zlatan-ibrahimovic",
+            "apiUrl": "https://content.guardianapis.com/football/zlatan-ibrahimovic",
+            "references": [
+
+            ],
+            "internalName": "Zlatan Ibrahimovic"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          }
+        ],
+        "elements": [
+
+        ],
+        "references": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/feb/14/james-richardson-european-football-papers-review-video",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-02-14T00:01:00Z",
+        "webTitle": "Rafael van der Vaart: 'We were frightened of our own supporters' – James Richardson's European football papers video review",
+        "webUrl": "https://www.theguardian.com/football/video/2014/feb/14/james-richardson-european-football-papers-review-video",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/feb/14/james-richardson-european-football-papers-review-video",
+        "tags": [
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "football/hamburg",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Hamburg",
+            "webUrl": "https://www.theguardian.com/football/hamburg",
+            "apiUrl": "https://content.guardianapis.com/football/hamburg",
+            "references": [
+
+            ],
+            "internalName": "Hamburg (Football club)"
+          },
+          {
+            "id": "football/bundesligafootball",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Bundesliga",
+            "webUrl": "https://www.theguardian.com/football/bundesligafootball",
+            "apiUrl": "https://content.guardianapis.com/football/bundesligafootball",
+            "references": [
+
+            ],
+            "internalName": "Bundesliga (Football)"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          }
+        ],
+        "elements": [
+
+        ],
+        "references": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      },
+      {
+        "id": "football/video/2014/feb/07/james-richardson-european-football-papers-video-review",
+        "type": "video",
+        "sectionId": "football",
+        "sectionName": "Football",
+        "webPublicationDate": "2014-02-07T00:01:00Z",
+        "webTitle": "'Beckham scores historic goal in Miami' – James Richardson's European football papers video review",
+        "webUrl": "https://www.theguardian.com/football/video/2014/feb/07/james-richardson-european-football-papers-video-review",
+        "apiUrl": "https://content.guardianapis.com/football/video/2014/feb/07/james-richardson-european-football-papers-video-review",
+        "tags": [
+          {
+            "id": "football/david-beckham",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "David Beckham",
+            "webUrl": "https://www.theguardian.com/football/david-beckham",
+            "apiUrl": "https://content.guardianapis.com/football/david-beckham",
+            "references": [
+
+            ],
+            "internalName": "David Beckham"
+          },
+          {
+            "id": "football/cagliari",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Cagliari",
+            "webUrl": "https://www.theguardian.com/football/cagliari",
+            "apiUrl": "https://content.guardianapis.com/football/cagliari",
+            "references": [
+
+            ],
+            "internalName": "Cagliari (Football club)"
+          },
+          {
+            "id": "football/spain",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Spain",
+            "webUrl": "https://www.theguardian.com/football/spain",
+            "apiUrl": "https://content.guardianapis.com/football/spain",
+            "references": [
+
+            ],
+            "internalName": "Spain football team"
+          },
+          {
+            "id": "football/football",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Football",
+            "webUrl": "https://www.theguardian.com/football/football",
+            "apiUrl": "https://content.guardianapis.com/football/football",
+            "references": [
+
+            ],
+            "internalName": "Football"
+          },
+          {
+            "id": "sport/sport",
+            "type": "keyword",
+            "sectionId": "sport",
+            "sectionName": "Sport",
+            "webTitle": "Sport",
+            "webUrl": "https://www.theguardian.com/sport/sport",
+            "apiUrl": "https://content.guardianapis.com/sport/sport",
+            "references": [
+
+            ],
+            "internalName": "Sport"
+          },
+          {
+            "id": "football/inter-miami",
+            "type": "keyword",
+            "sectionId": "football",
+            "sectionName": "Football",
+            "webTitle": "Inter Miami",
+            "webUrl": "https://www.theguardian.com/football/inter-miami",
+            "apiUrl": "https://content.guardianapis.com/football/inter-miami",
+            "references": [
+
+            ],
+            "internalName": "Inter Miami"
+          }
+        ],
+        "elements": [
+
+        ],
+        "references": [
+
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/sport",
+        "pillarName": "Sport"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What does this change?
We occasionally see alerts going off for high 5xx rates from the itunes-rss load balancer. On closer inspection it seems that any non-success code (usually 404s) were being returned as 500s.

This PR extends the `Good` `Or` `Bad` model a little by enclosing a `Failed` object in a `Bad` result that contains a message and status code that can be logged properly, and prevent 500s being returned when we're merely being asked for non-existent resources.

A new test is added using an example picked from live logs to check that the expected flavour of `Bad` is generated when the tag doesn't have a podcast field.

## How to test
We only have a PROD environment for this - so I'm hoping the unit test is sufficient 😬  Once deployed though we can  check manually but expect to see the culprit(s) asking for non-existent data and thus triggering the new code.

## How can we measure success?
We shouldn't return 5xx codes when we really mean 404

## Have we considered potential risks?
The podcast.xml endpoint may break. We can roll back if that happens.

## Images
N/A

## Accessibility
N/A
