### PR TITLE
Java 11 compile fix; linesIterator

### DIFF
--- a/test/com/gu/XmlTestUtils.scala
+++ b/test/com/gu/XmlTestUtils.scala
@@ -21,7 +21,7 @@ object XmlTestUtils {
    */
   def parseContentHtml(itemXml: Elem): Elem = {
     val text = (itemXml \ "encoded").head.text
-    val withoutDoctype = text.lines.drop(1).mkString("\n")
+    val withoutDoctype = text.linesIterator.drop(1).mkString("\n")
     XML.loadString(withoutDoctype)
   }
 


### PR DESCRIPTION
Avoids conflict with Java 11, which introduces `String::lines`

## What does this change?

Resolves a compile error in the tests which prevents this otherwise compatible project from compiling in Java 11.

Java 11 is the most recent Long Term Support Java release.
Play 2.6 claims to need Java 8 OR BETTER; hence we shouldn't need to be explicitly tied to Java 8.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Developers working on this project no longer need to explicitly switch back to Java 8 to work with this code.


## Have we considered potential risks?

Change is to test code only.
If this is incompatible with Java 8 then it should fail hard at the the build stage so should be safe.


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [x] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
