### PR TITLE
Ad free podcast responses for partner keys

### DIFF
--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -12,12 +12,12 @@ object iTunesRssFeed {
 
   val author = "The Guardian"
 
-  def apply(resp: ItemResponse): Node Or Failed = resp.tag match {
-    case Some(t) => toXml(t, resp.results.getOrElse(Nil).toList)
+  def apply(resp: ItemResponse, adFree: Boolean = false): Node Or Failed = resp.tag match {
+    case Some(t) => toXml(t, resp.results.getOrElse(Nil).toList, adFree)
     case None => Bad(Failed("tag not found", NotFound))
   }
 
-  def toXml(tag: Tag, contents: List[Content]): Node Or Failed = {
+  def toXml(tag: Tag, contents: List[Content], adFree: Boolean): Node Or Failed = {
 
     val description = Filtering.description(tag.description.getOrElse(""))
 
@@ -65,7 +65,7 @@ object iTunesRssFeed {
               for {
                 podcast <- contents
                 asset <- getFirstAudioAsset(podcast)
-              } yield new iTunesRssItem(podcast, tag.id, asset).toXml
+              } yield new iTunesRssItem(podcast, tag.id, asset, adFree).toXml
             }
           </channel>
         </rss>

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -5,7 +5,7 @@ import com.gu.contentapi.client.model.v1._
 
 import scala.xml.Node
 
-class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset) {
+class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFree: Boolean = false) {
 
   private val standfirstOrTrail = podcast.fields.flatMap(_.standfirst) orElse podcast.fields.flatMap(_.trailText)
 
@@ -26,46 +26,50 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset) {
       val launchDayPWNew = new DateTime(2018, 11, 15, 0, 0)
       val footballWeekly = new DateTime(2019, 4, 4, 0, 0)
 
-      if (tagId == "politics/series/politicsweekly") {
-        if (lastModified.isAfter(theMomentFrom))
-          """. Help support our independent journalism at <a href="https://www.theguardian.com/politicspod">theguardian.com/politicspod</a>"""
-        else if (lastModified.isAfter(launchDayPWNew))
-          """. To support The Guardian’s independent journalism, visit <a href="https://www.theguardian.com/give/podcast">theguardian.com/give/podcast</a>"""
-        else if (lastModified.isAfter(launchDayPW))
-          """. Please support our work and help us keep the world informed. To fund us, go to https://www.theguardian.com/give/podcast"""
-        else
+      if (!adFree) {
+        if (tagId == "politics/series/politicsweekly") {
+          if (lastModified.isAfter(theMomentFrom))
+            """. Help support our independent journalism at <a href="https://www.theguardian.com/politicspod">theguardian.com/politicspod</a>"""
+          else if (lastModified.isAfter(launchDayPWNew))
+            """. To support The Guardian’s independent journalism, visit <a href="https://www.theguardian.com/give/podcast">theguardian.com/give/podcast</a>"""
+          else if (lastModified.isAfter(launchDayPW))
+            """. Please support our work and help us keep the world informed. To fund us, go to https://www.theguardian.com/give/podcast"""
+          else
+            ""
+        } else if (tagId == "news/series/todayinfocus") {
+          if (lastModified.isAfter(theMomentFrom))
+            """. Help support our independent journalism at <a href="https://www.theguardian.com/infocus">theguardian.com/infocus</a>"""
+          else if (lastModified.isAfter(launchDayTIF))
+            """. To support The Guardian’s independent journalism, visit <a href="https://www.theguardian.com/todayinfocus/support">theguardian.com/todayinfocus/support</a>"""
+          else
+            ""
+        } else if (tagId == "books/series/books") {
+          if (lastModified.isAfter(theMomentFrom))
+            """. Help support our independent journalism at <a href="https://www.theguardian.com/bookspod">theguardian.com/bookspod</a>"""
+          else
+            ""
+        } else if (tagId == "news/series/the-audio-long-read") {
+          if (lastModified.isAfter(theMomentFrom))
+            """. Help support our independent journalism at <a href="https://www.theguardian.com/longreadpod">theguardian.com/longreadpod</a>"""
+          else
+            ""
+        } else if (tagId == "science/series/science") {
+          if (lastModified.isAfter(theMomentFrom))
+            """. Help support our independent journalism at <a href="https://www.theguardian.com/sciencepod">theguardian.com/sciencepod</a>"""
+          else
+            ""
+        } else if (tagId == "technology/series/chips-with-everything") {
+          if (lastModified.isAfter(theMomentFrom))
+            """. Help support our independent journalism at <a href="https://www.theguardian.com/chipspod">theguardian.com/chipspod</a>"""
+          else
+            ""
+        } else if (tagId == "football/series/footballweekly") {
+          if (lastModified.isAfter(footballWeekly))
+            """. Help support our independent journalism at <a href="https://www.theguardian.com/footballweeklypod">theguardian.com/footballweeklypod</a>"""
+          else ""
+        } else {
           ""
-      } else if (tagId == "news/series/todayinfocus") {
-        if (lastModified.isAfter(theMomentFrom))
-          """. Help support our independent journalism at <a href="https://www.theguardian.com/infocus">theguardian.com/infocus</a>"""
-        else if (lastModified.isAfter(launchDayTIF))
-          """. To support The Guardian’s independent journalism, visit <a href="https://www.theguardian.com/todayinfocus/support">theguardian.com/todayinfocus/support</a>"""
-        else
-          ""
-      } else if (tagId == "books/series/books") {
-        if (lastModified.isAfter(theMomentFrom))
-          """. Help support our independent journalism at <a href="https://www.theguardian.com/bookspod">theguardian.com/bookspod</a>"""
-        else
-          ""
-      } else if (tagId == "news/series/the-audio-long-read") {
-        if (lastModified.isAfter(theMomentFrom))
-          """. Help support our independent journalism at <a href="https://www.theguardian.com/longreadpod">theguardian.com/longreadpod</a>"""
-        else
-          ""
-      } else if (tagId == "science/series/science") {
-        if (lastModified.isAfter(theMomentFrom))
-          """. Help support our independent journalism at <a href="https://www.theguardian.com/sciencepod">theguardian.com/sciencepod</a>"""
-        else
-          ""
-      } else if (tagId == "technology/series/chips-with-everything") {
-        if (lastModified.isAfter(theMomentFrom))
-          """. Help support our independent journalism at <a href="https://www.theguardian.com/chipspod">theguardian.com/chipspod</a>"""
-        else
-          ""
-      } else if (tagId == "football/series/footballweekly") {
-        if (lastModified.isAfter(footballWeekly))
-          """. Help support our independent journalism at <a href="https://www.theguardian.com/footballweeklypod">theguardian.com/footballweeklypod</a>"""
-        else ""
+        }
       } else {
         ""
       }
@@ -131,9 +135,8 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset) {
         AcastLaunchGroup(new DateTime(2021, 6, 8, 0, 0), Seq(
           "lifeandstyle/series/comforteatingwithgracedent")))
 
-      val useAcastProxy: Boolean = acastPodcasts.find(_.tagIds.contains(tagId)).exists(p => lastModified.isAfter(p.launchDate))
+      val useAcastProxy = !adFree && acastPodcasts.find(_.tagIds.contains(tagId)).exists(p => lastModified.isAfter(p.launchDate))
       if (useAcastProxy) "https://flex.acast.com/" + url.replace("https://", "") else url
-
     }
 
     val description = Filtering.standfirst(standfirstOrTrail.getOrElse("")) + membershipCta

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,12 +1,12 @@
 package com.gu.itunes
 
-import com.gu.contentapi.client.model.{ContentApiError, ItemQuery}
+import com.gu.contentapi.client.model.{ ContentApiError, ItemQuery }
 import org.joda.time.format.DateTimeFormat
-import org.joda.time.{DateTime, DateTimeZone}
-import org.scalactic.{Bad, Good}
+import org.joda.time.{ DateTime, DateTimeZone }
+import org.scalactic.{ Bad, Good }
 import play.api.mvc.Results._
-import play.api.mvc.{BaseController, ControllerComponents, Result}
-import play.api.{Configuration, Logger}
+import play.api.mvc.{ BaseController, ControllerComponents, Result }
+import play.api.{ Configuration, Logger }
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -59,7 +59,7 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
     } yield {
       itemResponse.status match {
         case "ok" => {
-          val isAdFree = userApiKeyTier.contains("external")
+          val isAdFree = userApiKeyTier.contains("rights-managed")
           iTunesRssFeed(itemResponse, isAdFree) match {
             case Good(xml) =>
               val now = DateTime.now()

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -35,7 +35,7 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
     }
   }
 
-  def rawRss(tagId: String): Future[Result] = {
+  private def rawRss(tagId: String): Future[Result] = {
 
     val client = new CustomCapiClient(apiKey)
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -27,11 +27,13 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
   val cacheControl = s"max-age=$maxAge, stale-while-revalidate=$staleWhileRevalidateSeconds, stale-if-error=$oneDayInSeconds"
   private val HTTPDateFormat = DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'").withZone(DateTimeZone.UTC)
 
-  def itunesRss(tagId: String) = Action.async { implicit request =>
+  def itunesRss(tagId: String, userApiKey: Option[String]) = Action.async { implicit request =>
     val redirect = Redirection.redirect(tagId)
     redirect match {
-      case Some(redirectedTagId) => Future.successful(MovedPermanently(routes.Application.itunesRss(redirectedTagId).absoluteURL(true)))
-      case None => rawRss(tagId, apiKey)
+      case Some(redirectedTagId) => Future.successful(MovedPermanently(routes.Application.itunesRss(redirectedTagId, userApiKey).absoluteURL(true)))
+      case None =>
+        val apiKeyToUse = userApiKey.getOrElse(apiKey)
+        rawRss(tagId, apiKeyToUse)
     }
   }
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -74,6 +74,7 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
       }
     } recover {
       case ContentApiError(404, _, _) => NotFound
+      case ContentApiError(403, _, _) => Forbidden
       // maybe this generic InternalServerError could be a better representation of the CAPI failure mode
       case ContentApiError(status, msg, errorResponse) =>
         Logger.warn(s"Unexpected response code from CAPI. tagId = $tagId, HTTP status = $status, error response = $errorResponse")

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -31,11 +31,11 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
     val redirect = Redirection.redirect(tagId)
     redirect match {
       case Some(redirectedTagId) => Future.successful(MovedPermanently(routes.Application.itunesRss(redirectedTagId).absoluteURL(true)))
-      case None => rawRss(tagId)
+      case None => rawRss(tagId, apiKey)
     }
   }
 
-  private def rawRss(tagId: String): Future[Result] = {
+  private def rawRss(tagId: String, apiKey: String): Future[Result] = {
 
     val client = new CustomCapiClient(apiKey)
 

--- a/conf/routes
+++ b/conf/routes
@@ -3,7 +3,7 @@
 # ~~~~
 
 # Home page
-GET        /*tagId/podcast.xml      com.gu.itunes.Application.itunesRss(tagId: String, apiKey: Option[String])
+GET        /*tagId/podcast.xml      com.gu.itunes.Application.itunesRss(tagId: String, `api-key`: Option[String])
 
 
 GET        /healthcheck             com.gu.itunes.Application.healthcheck

--- a/conf/routes
+++ b/conf/routes
@@ -3,7 +3,7 @@
 # ~~~~
 
 # Home page
-GET        /*tagId/podcast.xml      com.gu.itunes.Application.itunesRss(tagId: String)
+GET        /*tagId/podcast.xml      com.gu.itunes.Application.itunesRss(tagId: String, apiKey: Option[String])
 
 
 GET        /healthcheck             com.gu.itunes.Application.healthcheck


### PR DESCRIPTION
## What does this change?

Syndication partners can trigger ad free podcasts by identifying themselves using an optional CAPI api key in their requests.

Podcast URLs will accept a user supplied CAPI key on the optional `api-key` query parameter.

ie.
Normal:
```
https://www.theguardian.com/australia-news/series/full-story/podcast.xml
````

Partner:
```
https://www.theguardian.com/australia-news/series/full-story/podcast.xml?api-key=im-a-syndication-partner
```

CAPI api keys are been used as the handle as that's what Content team members most closely associated with Syndication partners access .



If this key is provided we will make and additonal CAPI call to resolve it's user tier.
If the key belongs to the `external` user tier then ads (Acast ads and Membership call outs) will be omitted from the response.

The service will continue to user it's `internal` CAPI key as the podcast RSS response contains fields sourced from internal CAPI fields (namely the guid which we need to be stable to prevent mass invalidation of downloaded podcasts)

## How to test

Deploy locally and test with a partner key.

## How can we measure success?

No visible impact to normal requests.
A partner key can be used to obtain a feed response with no ads.

## Have we considered potential risks?

Is the `api-key` parameter considered part of any CDN caching?
Don't what ad free content to leak into the normal request responses.

Fastly's base hash includes query parameters:
https://developer.fastly.com/reference/vcl/subroutines/hash/

The Guardian's vcl config modifies the vcl_hash but seems to only append to the Fastly default so we are probably safe.



## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
