### PR TITLE
Revert "Increase maximum number of items on podcast response from 200 to 300"

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -43,7 +43,7 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
       .showElements("audio")
       .showTags("keyword")
       .showFields("all")
-      .pageSize(300) // number of podcasts to be served (max single request page size)
+      .pageSize(200) // number of podcasts to be served (max single request page size)
 
     (for {
       itemResponse <- client.getResponse(query)


### PR DESCRIPTION
Reverts guardian/itunes-rss#95