### PR TITLE
Ad free feeds do not include the new feed link tag

### DIFF
--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -25,7 +25,11 @@ object iTunesRssFeed {
       case Some(podcast) => Good {
         <rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
           <channel>
-            <itunes:new-feed-url>{ s"${tag.webUrl}/podcast.xml" }</itunes:new-feed-url>
+            {
+              if(!adFree) {
+                <itunes:new-feed-url>{s"${tag.webUrl}/podcast.xml"}</itunes:new-feed-url>
+              }
+            }
             <title>{ tag.webTitle }</title>
             <link>{ tag.webUrl }</link>
             <description>{ description }</description>

--- a/test/com/gu/ItunesRssFeedSpec.scala
+++ b/test/com/gu/ItunesRssFeedSpec.scala
@@ -37,6 +37,7 @@ class ItunesRssFeedSpec extends FlatSpec with ItunesTestData with Matchers {
           <itunes:summary>
             The Guardian's science team bring you the best analysis and interviews from the worlds of science and technology
           </itunes:summary>
+          <itunes:new-feed-url>https://www.theguardian.com/science/series/science/podcast.xml</itunes:new-feed-url>
           <image>
             <title>Science Weekly</title>
             <url>https://static.guim.co.uk/sitecrumbs/Guardian.gif</url>
@@ -48,20 +49,21 @@ class ItunesRssFeedSpec extends FlatSpec with ItunesTestData with Matchers {
         </channel>
       </rss>)
 
-    expectedXml \ "channel" \ "title" should be(currentXml \ "channel" \ "title")
-    expectedXml \ "channel" \ "link" should be(currentXml \ "channel" \ "link")
-    expectedXml \ "channel" \ "description" should be(currentXml \ "channel" \ "description")
-    expectedXml \ "channel" \ "language" should be(currentXml \ "channel" \ "language")
-    expectedXml \ "channel" \ "copyright" should be(currentXml \ "channel" \ "copyright")
-    expectedXml \ "channel" \ "type" should be(currentXml \ "channel" \ "type")
-    expectedXml \ "channel" \ "ttl" should be(currentXml \ "channel" \ "ttl")
-    expectedXml \ "channel" \ "owner" should be(currentXml \ "channel" \ "owner")
-    expectedXml \ "channel" \ "image" should be(currentXml \ "channel" \ "image")
-    expectedXml \ "channel" \ "author" should be(currentXml \ "channel" \ "author")
-    expectedXml \ "channel" \ "explicit" should be(currentXml \ "channel" \ "explicit")
-    expectedXml \ "channel" \ "summary" should be(currentXml \ "channel" \ "summary")
-    expectedXml \ "channel" \ "image" should be(currentXml \ "channel" \ "image")
-    expectedXml \ "channel" \ "category" should be(currentXml \ "channel" \ "category")
+    currentXml \ "channel" \ "title" should be(expectedXml \ "channel" \ "title")
+    currentXml \ "channel" \ "link" should be(expectedXml \ "channel" \ "link")
+    currentXml \ "channel" \ "description" should be(expectedXml \ "channel" \ "description")
+    currentXml \ "channel" \ "language" should be(expectedXml \ "channel" \ "language")
+    currentXml \ "channel" \ "copyright" should be(expectedXml \ "channel" \ "copyright")
+    currentXml \ "channel" \ "type" should be(expectedXml \ "channel" \ "type")
+    currentXml \ "channel" \ "ttl" should be(expectedXml \ "channel" \ "ttl")
+    currentXml \ "channel" \ "owner" should be(expectedXml \ "channel" \ "owner")
+    currentXml \ "channel" \ "image" should be(expectedXml \ "channel" \ "image")
+    currentXml \ "channel" \ "author" should be(expectedXml \ "channel" \ "author")
+    currentXml \ "channel" \ "explicit" should be(expectedXml \ "channel" \ "explicit")
+    currentXml \ "channel" \ "summary" should be(expectedXml \ "channel" \ "summary")
+    currentXml \ "channel" \ "image" should be(expectedXml \ "channel" \ "image")
+    currentXml \ "channel" \ "category" should be(expectedXml \ "channel" \ "category")
+    currentXml \ "channel" \ "new-feed-url" should be(expectedXml \ "channel" \ "new-feed-url")
   }
 
   it should "return a 404 if a podcast cannot be found" in {

--- a/test/com/gu/ItunesRssFeedSpec.scala
+++ b/test/com/gu/ItunesRssFeedSpec.scala
@@ -3,10 +3,10 @@ package com.gu.itunes
 
 import org.scalactic.Bad
 import org.scalatest._
-
-import scala.util.{ Failure, Success, Try }
-import scala.xml.Utility.trim
 import play.api.mvc.Results._
+
+import scala.util.Try
+import scala.xml.Utility.trim
 
 class ItunesRssFeedSpec extends FlatSpec with ItunesTestData with Matchers {
 
@@ -76,6 +76,13 @@ class ItunesRssFeedSpec extends FlatSpec with ItunesTestData with Matchers {
       case _ =>
         fail("""expected Bad(Failed("podcast not found", NotFound))""")
     }
+  }
+
+  it should "not show new-feed-url tag in ad free feeds to avoid confusing robots" in {
+    val currentXml = trim(iTunesRssFeed(itunesCapiResponse, adFree = true).get)
+
+    val itunesNewFeedUrl = (currentXml \\ "channel" \ "new-feed-url").find(_.prefix == "itunes")
+    itunesNewFeedUrl should be(None)
   }
 
 }

--- a/test/com/gu/ItunesRssItemSpec.scala
+++ b/test/com/gu/ItunesRssItemSpec.scala
@@ -104,6 +104,7 @@ class ItunesRssItemSpec extends FlatSpec with ItunesTestData with Matchers {
     val firstItemsItunesBlock = (podcasts \\ "item" \ "block").filter(_.prefix == "itunes").head
     firstItemsItunesBlock.text should be("yes")
   }
+
   it should "not prevent non ad free podcasts from been indexed" in {
     val results = itunesCapiResponse.results.getOrElse(Nil)
     val tagId = itunesCapiResponse.tag.get.id


### PR DESCRIPTION
## What does this change?

Do not render itunes:new-feed-url for ad free urls. 
We don't want to distract robots which might try to follow this redirection back to the public feeds.


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
