### PR TITLE
Validation linting. Channel image link matches channel link.

### DIFF
--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -60,7 +60,7 @@ object iTunesRssFeed {
             <image>
               <title>{ tag.webTitle }</title>
               <url>https://static.guim.co.uk/sitecrumbs/Guardian.gif</url>
-              <link>https://www.theguardian.com</link>
+              <link>{ tag.webUrl }</link>
             </image>
             {
               for (category <- podcast.categories.getOrElse(Nil)) yield new CategoryRss(category).toXml

--- a/test/com/gu/itunes/ItunesRssFeedSpec.scala
+++ b/test/com/gu/itunes/ItunesRssFeedSpec.scala
@@ -40,7 +40,7 @@ class ItunesRssFeedSpec extends FlatSpec with ItunesTestData with Matchers {
           <image>
             <title>Science Weekly</title>
             <url>https://static.guim.co.uk/sitecrumbs/Guardian.gif</url>
-            <link>https://www.theguardian.com</link>
+            <link>https://www.theguardian.com/science/series/science</link>
           </image>
           <itunes:category text="Health">
             <itunes:category text="Fitness &amp; Nutrition"/>
@@ -63,6 +63,9 @@ class ItunesRssFeedSpec extends FlatSpec with ItunesTestData with Matchers {
     currentXml \ "channel" \ "image" should be(expectedXml \ "channel" \ "image")
     currentXml \ "channel" \ "category" should be(expectedXml \ "channel" \ "category")
     currentXml \ "channel" \ "new-feed-url" should be(expectedXml \ "channel" \ "new-feed-url")
+
+    // Channel image link should match channel link
+    currentXml \ "channel" \ "image" \ "link" should be(currentXml \ "channel" \ "link")
   }
 
   it should "return a 404 if a podcast cannot be found" in {


### PR DESCRIPTION
Optional linting but the spec seems fairly clear in this one.

https://validator.w3.org/feed/docs/rss2.html#ltimagegtSubelementOfLtchannelgt
```
(Note, in practice the image <title> and <link> should have the same value as the channel's <title> and <link>.
```

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
