### PR TITLE
Omit itunes:subtitle field from ad free podcast feeds.

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -197,7 +197,11 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
         }
       }
       <itunes:keywords>{ keywords }</itunes:keywords>
-      <itunes:subtitle>{ subtitle }</itunes:subtitle>
+      {
+        if (!adFree) {
+          <itunes:subtitle>{ subtitle }</itunes:subtitle>
+        }
+      }
       <itunes:summary>{ scala.xml.Utility.escape(summary) }</itunes:summary>
       {
         if (adFree) {

--- a/test/com/gu/itunes/ItunesRssItemSpec.scala
+++ b/test/com/gu/itunes/ItunesRssItemSpec.scala
@@ -116,7 +116,7 @@ class ItunesRssItemSpec extends FlatSpec with ItunesTestData with Matchers {
     itunesBlockTag should be(None)
   }
 
-  it should "omit itunes:subtitle tag from ad free feeds as it is often or of spec" in {
+  it should "omit itunes:subtitle tag from ad free feeds as it is often out of spec" in {
     // Often exceeds 255 characters which is reported as a validation failure in the w3c feed validation tool.
     // Omit from ad free feeds to avoid validation rejections.
     val results = itunesCapiResponse.results.getOrElse(Nil)

--- a/test/com/gu/itunes/ItunesRssItemSpec.scala
+++ b/test/com/gu/itunes/ItunesRssItemSpec.scala
@@ -11,7 +11,7 @@ class ItunesRssItemSpec extends FlatSpec with ItunesTestData with Matchers {
 
     val results = itunesCapiResponse.results.getOrElse(Nil)
     val tagId = itunesCapiResponse.tag.get.id
-    val podcasts = for (p <- results) yield new iTunesRssItem(p, tagId, p.elements.get.head.assets.head).toXml
+    val podcasts = for (p <- results) yield new iTunesRssItem(p, tagId, p.elements.get.head.assets.head, adFree = false).toXml
     val trimmedPodcasts = for (p <- podcasts) yield trim(p)
 
     val expectedXml = RemoveWhitespace.transform(
@@ -79,6 +79,7 @@ class ItunesRssItemSpec extends FlatSpec with ItunesTestData with Matchers {
           Neuroscientist David Eagleman discusses how neuroscience and technology are reshaping how we understand our brains
         </itunes:summary>
       </item>)
+
     val result = trimmedPodcasts zip expectedXml
 
     result foreach (x => x._1 \ "title" should be(x._2 \ "title"))
@@ -113,6 +114,18 @@ class ItunesRssItemSpec extends FlatSpec with ItunesTestData with Matchers {
 
     val itunesBlockTag = (podcasts \\ "item" \ "block").find(_.prefix == "itunes")
     itunesBlockTag should be(None)
+  }
+
+  it should "omit itunes:subtitle tag from ad free feeds is it is often or of spec" in {
+    // Often exceeds 255 characters which is reported as a validation failure in the w3c feed validation tool.
+    // Omit from ad free feeds to avoid validation rejections.
+    val results = itunesCapiResponse.results.getOrElse(Nil)
+    val tagId = itunesCapiResponse.tag.get.id
+
+    val podcasts = for (p <- results) yield new iTunesRssItem(p, tagId, p.elements.get.head.assets.head, true).toXml
+
+    val firstItemsItunesBlock = (podcasts \\ "item" \ "subtitle").filter(_.prefix == "itunes")
+    firstItemsItunesBlock.headOption should be(None)
   }
 
 }

--- a/test/com/gu/itunes/ItunesRssItemSpec.scala
+++ b/test/com/gu/itunes/ItunesRssItemSpec.scala
@@ -116,7 +116,7 @@ class ItunesRssItemSpec extends FlatSpec with ItunesTestData with Matchers {
     itunesBlockTag should be(None)
   }
 
-  it should "omit itunes:subtitle tag from ad free feeds is it is often or of spec" in {
+  it should "omit itunes:subtitle tag from ad free feeds as it is often or of spec" in {
     // Often exceeds 255 characters which is reported as a validation failure in the w3c feed validation tool.
     // Omit from ad free feeds to avoid validation rejections.
     val results = itunesCapiResponse.results.getOrElse(Nil)


### PR DESCRIPTION
Often too long and out of spec which causes the feed to be rejected by consumers who strictly validate it.

Appears not to effect the rendering of Apple of Google Podcast apps.
Safe to remove from syndication feeds. Probably possible to retire from all feeds in the future.


## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
