### PR TITLE
Move test class files to match Java style package folder layout

### DIFF
--- a/test/com/gu/itunes/AcastProxySpec.scala
+++ b/test/com/gu/itunes/AcastProxySpec.scala
@@ -1,7 +1,7 @@
 package com.gu.itunes
 
 import com.gu.contentapi.client.model.v1._
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.{FlatSpec, Matchers}
 
 class AcastProxySpec extends FlatSpec with Matchers with ItunesTestData {
 

--- a/test/com/gu/itunes/FilteringSpec.scala
+++ b/test/com/gu/itunes/FilteringSpec.scala
@@ -1,6 +1,6 @@
 package com.gu.itunes
 
-import org.scalatest.{ Matchers, FlatSpec }
+import org.scalatest.{FlatSpec, Matchers}
 
 class FilteringSpec extends FlatSpec with Matchers {
 

--- a/test/com/gu/itunes/ItunesRssFeedSpec.scala
+++ b/test/com/gu/itunes/ItunesRssFeedSpec.scala
@@ -1,4 +1,3 @@
-
 package com.gu.itunes
 
 import org.scalactic.Bad

--- a/test/com/gu/itunes/ItunesTestData.scala
+++ b/test/com/gu/itunes/ItunesTestData.scala
@@ -1,12 +1,13 @@
 package com.gu.itunes
 
-import java.nio.charset.StandardCharsets
+import cats.syntax.either._
 import com.google.common.io.Resources
 import com.gu.contentapi.client.model.v1.ItemResponse
 import com.gu.contentapi.json.CirceDecoders.itemResponseDecoder
-import io.circe.{ Decoder, Json }
 import io.circe.parser._
-import cats.syntax.either._
+import io.circe.{Decoder, Json}
+
+import java.nio.charset.StandardCharsets
 
 trait ItunesTestData {
 

--- a/test/com/gu/itunes/XmlTestUtils.scala
+++ b/test/com/gu/itunes/XmlTestUtils.scala
@@ -1,7 +1,7 @@
 package com.gu.itunes
 
-import scala.xml.transform.{ RewriteRule, RuleTransformer }
-import scala.xml.{ XML, Elem, Node, Text }
+import scala.xml.transform.{RewriteRule, RuleTransformer}
+import scala.xml.{Elem, Node, Text, XML}
 
 object XmlTestUtils {
 
@@ -17,6 +17,7 @@ object XmlTestUtils {
 
   /**
    * Extract the contents of an RSS item's <content:encoded> tag as XML.
+   *
    * @param itemXml the RSS item as XML
    */
   def parseContentHtml(itemXml: Elem): Elem = {


### PR DESCRIPTION
Was probably valid Scala but confused the IDE. 
Java style layout gives a better unboxing in the IDE.

Resolves IDE warnings like this:
<img width="601" alt="package-warning" src="https://user-images.githubusercontent.com/150238/127363595-56f6ceb6-7b9f-45d2-9db8-20ce2e098bad.png">



## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)

