### PR TITLE
Use the shorter content trailtext to populate the itunes:subtitle tag

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -199,7 +199,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
       }
       <itunes:keywords>{ keywords }</itunes:keywords>
       {
-        if (subtitle.length <= 255 && !adFree) {
+        if (!adFree) {
           <itunes:subtitle>{ subtitle }</itunes:subtitle>
         }
       }

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -7,7 +7,8 @@ import scala.xml.Node
 
 class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFree: Boolean = false) {
 
-  private val standfirstOrTrail = podcast.fields.flatMap(_.standfirst) orElse podcast.fields.flatMap(_.trailText)
+  private val trailText = podcast.fields.flatMap(_.trailText)
+  private val standfirstOrTrail = podcast.fields.flatMap(_.standfirst) orElse trailText
 
   def toXml: Node = {
 
@@ -178,7 +179,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
 
     val keywords = makeKeywordsList(podcast.tags)
 
-    val subtitle = Filtering.standfirst(standfirstOrTrail.getOrElse(""))
+    val subtitle = Filtering.standfirst(trailText.getOrElse(""))
 
     val summary = Filtering.standfirst(standfirstOrTrail.getOrElse("")) + membershipCta
 
@@ -198,7 +199,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
       }
       <itunes:keywords>{ keywords }</itunes:keywords>
       {
-        if (!adFree) {
+        if (subtitle.length <= 255 && !adFree) {
           <itunes:subtitle>{ subtitle }</itunes:subtitle>
         }
       }

--- a/test/com/gu/itunes/ItunesRssItemSpec.scala
+++ b/test/com/gu/itunes/ItunesRssItemSpec.scala
@@ -124,8 +124,18 @@ class ItunesRssItemSpec extends FlatSpec with ItunesTestData with Matchers {
 
     val podcasts = for (p <- results) yield new iTunesRssItem(p, tagId, p.elements.get.head.assets.head, true).toXml
 
-    val firstItemsItunesBlock = (podcasts \\ "item" \ "subtitle").filter(_.prefix == "itunes")
-    firstItemsItunesBlock.headOption should be(None)
+    val firstItemSubtitleTag = (podcasts \\ "item" \ "subtitle").find(_.prefix == "itunes")
+    firstItemSubtitleTag should be(None)
+  }
+
+  it should "use shorter trailtext for itunes:subtitle to help stay within the w3c 255 character limit" in {
+    val results = itunesCapiResponse.results.getOrElse(Nil)
+    val tagId = itunesCapiResponse.tag.get.id
+
+    val podcasts = for (p <- results) yield new iTunesRssItem(p, tagId, p.elements.get.head.assets.head, false).toXml
+
+    val itemSubtitleTags = (podcasts \\ "item" \ "subtitle").filter(_.prefix == "itunes")
+    itemSubtitleTags.lastOption.map(_.text) should be(Some("Guardian Australia editor Lenore Taylor and head of news Mike Ticher discuss the expansion of Covid financial support in NSW"))
   }
 
 }

--- a/test/resources/itunes-capi-response.json
+++ b/test/resources/itunes-capi-response.json
@@ -4,7 +4,7 @@
     "userTier": "internal",
     "total": 563,
     "startIndex": 1,
-    "pageSize": 3,
+    "pageSize": 4,
     "currentPage": 1,
     "pages": 188,
     "orderBy": "newest",
@@ -269,6 +269,136 @@
             "sectionName": "Science"
           }
         ]
+      },
+      {
+        "id": "australia-news/audio/2021/jul/30/are-the-nsw-covid-disaster-payments-too-little-too-late-with-lenore-taylor",
+        "type": "audio",
+        "sectionId": "australia-news",
+        "sectionName": "Australia news",
+        "webPublicationDate": "2021-07-29T17:30:38Z",
+        "webTitle": "Are the NSW Covid disaster payments too little too late? – with Lenore Taylor ",
+        "webUrl": "https://www.theguardian.com/australia-news/audio/2021/jul/30/are-the-nsw-covid-disaster-payments-too-little-too-late-with-lenore-taylor",
+        "apiUrl": "https://content.guardianapis.com/australia-news/audio/2021/jul/30/are-the-nsw-covid-disaster-payments-too-little-too-late-with-lenore-taylor",
+        "fields": {
+          "headline": "Are the NSW Covid disaster payments too little too late? – with Lenore Taylor ",
+          "standfirst": "<p>As the NSW Covid outbreak continues and millions of Australians struggle to access the financial support they need, the state and federal governments have announced increased Covid support payments. Guardian Australia editor Lenore Taylor and head of news Mike Ticher discuss if this expansion of financial support has hit the mark</p>",
+          "trailText": "Guardian Australia editor Lenore Taylor and head of news Mike Ticher discuss the expansion of Covid financial support in NSW",
+          "byline": "Presented by Gabrielle Jackson with Lenore Taylor and Mike Ticher. Produced by Miles Herbert and Joe Koning. The executive producers are Miles Martignoni and Gabrielle Jackson",
+          "main": "<!-- Invalid audio element without \"html\" field -->",
+          "body": "<p>Read more:</p> <ul> <li><strong><a href=\"https://www.theguardian.com/commentisfree/2021/jul/28/nsw-must-quash-the-covid-outbreak-and-it-cant-without-fair-and-just-income-support\">Excluding the most vulnerable from Covid payments isn’t just cruel – it jeopardises public health </a></strong></li> </ul>",
+          "wordcount": "16",
+          "creationDate": "2021-07-29T06:49:33Z",
+          "firstPublicationDate": "2021-07-29T17:30:38Z",
+          "internalComposerCode": "61024f7d8f089093df86d929",
+          "internalPageCode": "9776795",
+          "isInappropriateForSponsorship": "false",
+          "isPremoderated": "false",
+          "lastModified": "2021-07-29T17:30:38Z",
+          "productionOffice": "AUS",
+          "publication": "theguardian.com",
+          "shortUrl": "https://www.theguardian.com/p/taj6e",
+          "shouldHideAdverts": "false",
+          "showInRelatedContent": "true",
+          "thumbnail": "https://media.guim.co.uk/2b5ca6f9a99c487385c6b541c4a72117a134d87d/0_62_3916_2350/500.jpg",
+          "legallySensitive": "false",
+          "lang": "en",
+          "internalRevision": "164",
+          "isLive": "true",
+          "internalShortId": "/p/taj6e",
+          "bodyText": "Read more: Excluding the most vulnerable from Covid payments isn’t just cruel – it jeopardises public health",
+          "charCount": "108",
+          "shouldHideReaderRevenue": "false",
+          "showAffiliateLinks": "false",
+          "bylineHtml": "Presented by <a href=\"profile/gabrielle-jackson\">Gabrielle Jackson</a> with <a href=\"profile/lenore-taylor\">Lenore Taylor</a> and <a href=\"profile/miketicher\">Mike Ticher</a>. Produced by <a href=\"profile/miles-herbert\">Miles Herbert</a> and <a href=\"profile/joe-koning\">Joe Koning</a>. The executive producers are <a href=\"profile/miles-martignoni\">Miles Martignoni</a> and <a href=\"profile/gabrielle-jackson\">Gabrielle Jackson</a>"
+        },
+        "elements": [
+          {
+            "id": "gu-audio-61024f7d8f089093df86d929",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2021/07/29-32759-fs_friday_jobsaver.mp3",
+                "typeData": {
+                  "source": "guardian",
+                  "secureFile": "https://audio.guim.co.uk/2021/07/29-32759-fs_friday_jobsaver.mp3",
+                  "sizeInBytes": "30513778",
+                  "durationMinutes": "21",
+                  "durationSeconds": "11",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "2b5ca6f9a99c487385c6b541c4a72117a134d87d",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/2b5ca6f9a99c487385c6b541c4a72117a134d87d/0_62_3916_2350/master/3916.jpg",
+                "typeData": {
+                  "altText": "NSW Treasurer Dominic Perrottet, Prime Minister Scott Morrison and NSW Premier Gladys Berejiklian",
+                  "credit": "Photograph: Mick Tsikas/AAP",
+                  "photographer": "Mick Tsikas",
+                  "source": "AAP",
+                  "width": "3916",
+                  "height": "2350",
+                  "secureFile": "https://media.guim.co.uk/2b5ca6f9a99c487385c6b541c4a72117a134d87d/0_62_3916_2350/master/3916.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "2b5ca6f9a99c487385c6b541c4a72117a134d87d",
+                  "imageType": "Photograph",
+                  "suppliersReference": "60ed24a0ed2829ad82a905dd",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/2b5ca6f9a99c487385c6b541c4a72117a134d87d"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/2b5ca6f9a99c487385c6b541c4a72117a134d87d/0_62_3916_2350/3916.jpg",
+                "typeData": {
+                  "altText": "NSW Treasurer Dominic Perrottet, Prime Minister Scott Morrison and NSW Premier Gladys Berejiklian",
+                  "credit": "Photograph: Mick Tsikas/AAP",
+                  "photographer": "Mick Tsikas",
+                  "source": "AAP",
+                  "width": "3916",
+                  "height": "2350",
+                  "secureFile": "https://media.guim.co.uk/2b5ca6f9a99c487385c6b541c4a72117a134d87d/0_62_3916_2350/3916.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "2b5ca6f9a99c487385c6b541c4a72117a134d87d",
+                  "imageType": "Photograph",
+                  "suppliersReference": "60ed24a0ed2829ad82a905dd",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/2b5ca6f9a99c487385c6b541c4a72117a134d87d"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/2b5ca6f9a99c487385c6b541c4a72117a134d87d/0_62_3916_2350/500.jpg",
+                "typeData": {
+                  "altText": "NSW Treasurer Dominic Perrottet, Prime Minister Scott Morrison and NSW Premier Gladys Berejiklian",
+                  "credit": "Photograph: Mick Tsikas/AAP",
+                  "photographer": "Mick Tsikas",
+                  "source": "AAP",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/2b5ca6f9a99c487385c6b541c4a72117a134d87d/0_62_3916_2350/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "2b5ca6f9a99c487385c6b541c4a72117a134d87d",
+                  "imageType": "Photograph",
+                  "suppliersReference": "60ed24a0ed2829ad82a905dd",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/2b5ca6f9a99c487385c6b541c4a72117a134d87d"
+                }
+              }
+            ]
+          }
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/news",
+        "pillarName": "News"
       }
     ],
     "leadContent": [


### PR DESCRIPTION
Rather than the generally longer stand first. 

Limit to 255 characters.
Drop back to an empty (but present) tag if the trailtext is over length. There is already precedent in the code for this approach.

Reacts to w3c feed validation errors. The original specification for itunes:subtitle is lost to history and we can't find an up to date citation other than the w3c feed validator.

The itunes:subtitle does not appear to effect the end user rendering in current versions of Apple and Google podcast apps. This can be checked by examining podcasts from other publishers (like the BBC) who already have unique text in the itunes:subtitle field; it doesn't show in the apps.


<img width="1028" alt="Screenshot 2021-07-30 at 09 20 35" src="https://user-images.githubusercontent.com/150238/127625890-6892c491-260e-4104-89ac-565b2712fe01.png">

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
