### PR TITLE
For ad free feeds the channel image is the same large podcast specific image

### DIFF
--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -26,8 +26,8 @@ object iTunesRssFeed {
         <rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
           <channel>
             {
-              if(!adFree) {
-                <itunes:new-feed-url>{s"${tag.webUrl}/podcast.xml"}</itunes:new-feed-url>
+              if (!adFree) {
+                <itunes:new-feed-url>{ s"${tag.webUrl}/podcast.xml" }</itunes:new-feed-url>
               }
             }
             <title>{ tag.webTitle }</title>
@@ -59,7 +59,13 @@ object iTunesRssFeed {
             <itunes:summary>{ description }</itunes:summary>
             <image>
               <title>{ tag.webTitle }</title>
-              <url>https://static.guim.co.uk/sitecrumbs/Guardian.gif</url>
+              {
+                if (adFree) {
+                  <url>{ podcast.image.getOrElse("https://static.guim.co.uk/sitecrumbs/Guardian.gif") }</url>
+                } else {
+                  <url>https://static.guim.co.uk/sitecrumbs/Guardian.gif</url>
+                }
+              }
               <link>{ tag.webUrl }</link>
             </image>
             {

--- a/test/com/gu/itunes/ItunesRssFeedSpec.scala
+++ b/test/com/gu/itunes/ItunesRssFeedSpec.scala
@@ -87,4 +87,12 @@ class ItunesRssFeedSpec extends FlatSpec with ItunesTestData with Matchers {
     itunesNewFeedUrl should be(None)
   }
 
+  it should "show large image specific to this podcast on the channel image tag for ad free feeds" in {
+    val currentXml = trim(iTunesRssFeed(itunesCapiResponse, adFree = true).get)
+
+    val channelImageUrl = currentXml \\ "channel" \ "image" \ "url"
+
+    channelImageUrl.text should be("https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/4/22/1398182483649/ScienceWeekly.png")
+  }
+
 }


### PR DESCRIPTION
The same as `itunes:image`.

Brings the `<image>` tag inline with Apple's artwork guidelines for ad free feeds.
ie. https://podcasters.apple.com/support/896-artwork-requirements

This is as specific partner request but possibly applicable in general. Applying to ad free initially to keep the review scope smaller.

Apple do not document the usage of the `<image>` tag so it's more differcult to know if this should be applied to the public feeds `<image>` tag.
ie. https://help.apple.com/itc/podcasts_connect/?lang=en#/itcb54353390

Apple talk about the `<itunes:image>` tag. 
Modern iOS and Android podcast clients do not render the small .gif logo from the `<image>`  tag.


## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
