### PR TITLE
More items

### DIFF
--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -1,6 +1,5 @@
 package com.gu.itunes
 
-import com.gu.contentapi.client.model.v1.ItemResponse
 import com.gu.contentapi.client.model.v1._
 import org.joda.time.DateTime
 import org.scalactic.{ Bad, Good, Or }
@@ -12,9 +11,14 @@ object iTunesRssFeed {
 
   val author = "The Guardian"
 
-  def apply(resp: ItemResponse, adFree: Boolean = false): Node Or Failed = resp.tag match {
-    case Some(t) => toXml(t, resp.results.getOrElse(Nil).toList, adFree)
-    case None => Bad(Failed("tag not found", NotFound))
+  def apply(resps: Seq[ItemResponse], adFree: Boolean = false): Node Or Failed = {
+    val tag = resps.headOption.flatMap(_.tag)
+    tag match {
+      case Some(t) =>
+        val content = resps.flatMap(_.results.getOrElse(Nil)).toList
+        toXml(t, content, adFree)
+      case None => Bad(Failed("tag not found", NotFound))
+    }
   }
 
   def toXml(tag: Tag, contents: List[Content], adFree: Boolean): Node Or Failed = {

--- a/test/com/gu/itunes/ItunesRssFeedSpec.scala
+++ b/test/com/gu/itunes/ItunesRssFeedSpec.scala
@@ -11,7 +11,7 @@ class ItunesRssFeedSpec extends FlatSpec with ItunesTestData with Matchers {
 
   it should "check that the produced XML for the tags is consistent" in {
 
-    val currentXml = trim(iTunesRssFeed(itunesCapiResponse).get)
+    val currentXml = trim(iTunesRssFeed(Seq(itunesCapiResponse)).get)
 
     val expectedXml = trim(
       <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
@@ -69,7 +69,7 @@ class ItunesRssFeedSpec extends FlatSpec with ItunesTestData with Matchers {
   }
 
   it should "return a 404 if a podcast cannot be found" in {
-    val attempt = Try(iTunesRssFeed(tagMissingPodcastFieldResponse))
+    val attempt = Try(iTunesRssFeed(Seq(tagMissingPodcastFieldResponse)))
     attempt.get match {
       case Bad(failed: Failed) =>
         failed.message should be("podcast not found")
@@ -81,14 +81,14 @@ class ItunesRssFeedSpec extends FlatSpec with ItunesTestData with Matchers {
   }
 
   it should "not show new-feed-url tag in ad free feeds to avoid confusing robots" in {
-    val currentXml = trim(iTunesRssFeed(itunesCapiResponse, adFree = true).get)
+    val currentXml = trim(iTunesRssFeed(Seq(itunesCapiResponse), adFree = true).get)
 
     val itunesNewFeedUrl = (currentXml \\ "channel" \ "new-feed-url").find(_.prefix == "itunes")
     itunesNewFeedUrl should be(None)
   }
 
   it should "show large image specific to this podcast on the channel image tag for ad free feeds" in {
-    val currentXml = trim(iTunesRssFeed(itunesCapiResponse, adFree = true).get)
+    val currentXml = trim(iTunesRssFeed(Seq(itunesCapiResponse), adFree = true).get)
 
     val channelImageUrl = currentXml \\ "channel" \ "image" \ "url"
 


### PR DESCRIPTION
## What does this change?

Paginate multiple sequential CAPI requests to return podcast feeds with more items the the maximum single page CAPI response.

Finding the most certain off one error in this is left as an exercise for the reader.

## How to test

Time considerations are important here but it looks like's still sub second response time:
```
time curl http://localhost:9000/australia-news/series/full-story/podcast.xml  > /dev/null 
curl http://localhost:9000/australia-news/series/full-story/podcast.xml >   0.00s user 0.01s system 2% cpu 0.405 total
```

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
