### PR TITLE
Minimise the number of requested item fields

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -42,7 +42,7 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
     val query = ItemQuery(tagId)
       .showElements("audio")
       .showTags("keyword")
-      .showFields("all")
+      .showFields("webTitle,webPublicationDate,standfirst,trailText,internalComposerCode")
       .pageSize(200) // number of podcasts to be served (max single request page size)
 
     (for {

--- a/test/com/gu/itunes/ItunesTestData.scala
+++ b/test/com/gu/itunes/ItunesTestData.scala
@@ -5,7 +5,7 @@ import com.google.common.io.Resources
 import com.gu.contentapi.client.model.v1.ItemResponse
 import com.gu.contentapi.json.CirceDecoders.itemResponseDecoder
 import io.circe.parser._
-import io.circe.{Decoder, Json}
+import io.circe.{ Decoder, Json }
 
 import java.nio.charset.StandardCharsets
 
@@ -15,11 +15,11 @@ trait ItunesTestData {
 
   /*
     Search response from CAPI. The URL used is:
-    guardianapis.com/science/series/science?show-fields=all&show-elements=audio&show-tags=keyword&page-size=3
+    guardianapis.com/science/series/science?show-fields=webTitle%2CwebPublicationDate%2Cstandfirst%2CtrailText%2CinternalComposerCode&show-elements=audio&show-tags=keyword&page-size=3
   */
 
   val itunesCapiResponse: ItemResponse = {
-    val json = loadJson("itunes-capi-response.json")
+    val json = loadJson("itunes-capi-sparse-response.json")
     parseJson[ItemResponse](json)
   }
 

--- a/test/resources/itunes-capi-sparse-response.json
+++ b/test/resources/itunes-capi-sparse-response.json
@@ -1,0 +1,612 @@
+{
+  "response": {
+    "status": "ok",
+    "userTier": "internal",
+    "total": 563,
+    "startIndex": 1,
+    "pageSize": 4,
+    "currentPage": 1,
+    "pages": 188,
+    "orderBy": "newest",
+    "tag": {
+      "podcast": {
+        "explicit": false,
+        "image": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/4/22/1398182483649/ScienceWeekly.png",
+        "copyright": "theguardian.com © 2014",
+        "author": "The Guardian",
+        "linkUrl": "https://www.theguardian.com",
+        "subscriptionUrl": "http://phobos.apple.com/WebObjects/MZStore.woa/wa/viewPodcast?id=136697669",
+        "categories": [
+            {
+                "main":"Health",
+                "sub":"Fitness & Nutrition"
+            }
+        ],
+        "podcastType": "Serial"
+      },
+      "webTitle": "Science Weekly",
+      "description": "The Guardian's science team bring you the best analysis and interviews from the worlds of science and technology",
+      "id": "science/series/science",
+      "sectionId": "science",
+      "type": "series",
+      "webUrl": "https://www.theguardian.com/science/series/science",
+      "apiUrl": "https://content.guardianapis.com/science/series/science",
+      "sectionName": "Science"
+    },
+    "results": [
+      {
+        "id": "science/audio/2019/jan/20/mathematics-john-conway-numbers-game-theory",
+        "type": "podcast",
+        "sectionId": "science",
+        "webTitle": "Inside the mind of renowned mathematician John Conway - podcast",
+        "webPublicationDate": "2019-01-20T07:30:00Z",
+        "fields": {
+          "internalComposerCode": "composer-code-123",
+          "standfirst": "John Conway sheds light on the true nature of numbers, the beauty lying within maths and why game-playing is so important to mathematical discovery",
+          "trailText": "<p>John Conway sheds light on the true nature of numbers, the beauty lying within maths and why game-playing is so important to mathematical discovery</p>"
+        },
+        "webUrl": "https://www.theguardian.com/science/audio/2015/nov/20/mathematics-john-conway-numbers-game-theory",
+        "apiUrl": "https://content.guardianapis.com/science/audio/2015/nov/20/mathematics-john-conway-numbers-game-theory",
+        "sectionName": "Science",
+        "elements": [
+          {
+            "id": "gu-audio-458409634",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "http://static.guim.co.uk/audio/kip/science/series/science/1447948283860/6835/gdn.sci.151120.ic.Science_Weekly_2.mp3",
+                "typeData": {
+                  "explicit": "false",
+                  "source": "Guardian",
+                  "durationMinutes": "29",
+                  "durationSeconds": "7"
+                }
+              }
+            ]
+          }
+        ],
+        "tags": [
+          {
+            "id": "science/science",
+            "webTitle": "Science",
+            "type": "keyword",
+            "sectionId": "science",
+            "webUrl": "https://www.theguardian.com/science/science",
+            "apiUrl": "https://content.guardianapis.com/science/science",
+            "sectionName": "Science"
+          },
+          {
+            "id": "science/mathematics",
+            "webTitle": "Mathematics",
+            "type": "keyword",
+            "sectionId": "science",
+            "webUrl": "https://www.theguardian.com/science/mathematics",
+            "apiUrl": "https://content.guardianapis.com/science/mathematics",
+            "sectionName": "Science"
+          }
+        ]
+      },
+      {
+        "id": "science/audio/2015/nov/13/conspiracy-theories-david-icke",
+        "type": "podcast",
+        "sectionId": "science",
+        "webTitle": "Why are conspiracy theories so attractive? podcast",
+        "webPublicationDate": "2015-12-04T12:04:27+01:00",
+        "fields": {
+          "standfirst": "Should we distrust our own ability to reason? Why is debunking conspiracy theories such a risky business? And is David Icke a force for good?",
+          "internalContentCode": "458381209",
+          "trailText": "<p>Should we distrust our own ability to reason? Why is debunking conspiracy theories such a risky business? And is David Icke a force for good?</p>"
+        },
+        "webUrl": "https://www.theguardian.com/science/audio/2015/nov/13/conspiracy-theories-david-icke",
+        "apiUrl": "https://content.guardianapis.com/science/audio/2015/nov/13/conspiracy-theories-david-icke",
+        "sectionName": "Science",
+        "elements": [
+          {
+            "id": "gu-audio-458381209",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2015/12/03-53462-gdn.tech.151203.sb.digital-babysitting.mp3",
+                "typeData": {
+                  "explicit": "true",
+                  "source": "Guardian",
+                  "durationMinutes": "27",
+                  "durationSeconds": "0"
+                }
+              }
+            ]
+          }
+        ],
+        "tags": [
+          {
+            "id": "science/science",
+            "webTitle": "Science",
+            "type": "keyword",
+            "sectionId": "science",
+            "webUrl": "https://www.theguardian.com/science/science",
+            "apiUrl": "https://content.guardianapis.com/science/science",
+            "sectionName": "Science"
+          },
+          {
+            "id": "science/psychology",
+            "webTitle": "Psychology",
+            "type": "keyword",
+            "sectionId": "science",
+            "webUrl": "https://www.theguardian.com/science/psychology",
+            "apiUrl": "https://content.guardianapis.com/science/psychology",
+            "sectionName": "Science"
+          }
+        ]
+      },
+      {
+        "id": "science/audio/2015/nov/06/science-weekly-podcast-story-brain-david-eagleman-neuroscience",
+        "type": "podcast",
+        "sectionId": "science",
+        "webTitle": "The story of our brains - podcast",
+        "webPublicationDate": "2015-11-06T07:30:00Z",
+        "fields": {
+          "standfirst": "Neuroscientist David Eagleman discusses how neuroscience and technology are reshaping how we understand our brains",
+          "internalContentCode": "458329008",
+          "trailText": "<p>Neuroscientist David Eagleman discusses how neuroscience and technology are reshaping how we understand our brains</p>"
+        },
+        "webUrl": "https://www.theguardian.com/science/audio/2015/nov/06/science-weekly-podcast-story-brain-david-eagleman-neuroscience",
+        "apiUrl": " ",
+        "sectionName": "Science",
+        "elements": [
+          {
+            "id": "gu-audio-458329008",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://static-secure.guim.co.uk/audio/kip/science/series/science/1446638390950/3741/gdn.sci.151106.ic.Science_Weekly.mp3",
+                "typeData": {
+                  "explicit": "false",
+                  "source": "Guardian",
+                  "durationMinutes": "25",
+                  "durationSeconds": "37",
+                  "clean": "true"
+                }
+              }
+            ]
+          }
+        ],
+        "tags": [
+          {
+            "id": "science/science",
+            "webTitle": "Science",
+            "type": "keyword",
+            "sectionId": "science",
+            "webUrl": "https://www.theguardian.com/science/science",
+            "apiUrl": "https://content.guardianapis.com/science/science",
+            "sectionName": "Science"
+          },
+          {
+            "id": "books/david-eagleman",
+            "webTitle": "David Eagleman",
+            "type": "keyword",
+            "sectionId": "books",
+            "webUrl": "https://www.theguardian.com/books/david-eagleman",
+            "apiUrl": "https://content.guardianapis.com/books/david-eagleman",
+            "sectionName": "Books"
+          },
+          {
+            "id": "science/neuroscience",
+            "webTitle": "Neuroscience",
+            "type": "keyword",
+            "sectionId": "science",
+            "webUrl": "https://www.theguardian.com/science/neuroscience",
+            "apiUrl": "https://content.guardianapis.com/science/neuroscience",
+            "sectionName": "Science"
+          }
+        ]
+      },
+      {
+        "id": "australia-news/audio/2021/jul/30/are-the-nsw-covid-disaster-payments-too-little-too-late-with-lenore-taylor",
+        "type": "audio",
+        "sectionId": "australia-news",
+        "sectionName": "Australia news",
+        "webPublicationDate": "2021-07-29T17:30:38Z",
+        "webTitle": "Are the NSW Covid disaster payments too little too late? – with Lenore Taylor ",
+        "webUrl": "https://www.theguardian.com/australia-news/audio/2021/jul/30/are-the-nsw-covid-disaster-payments-too-little-too-late-with-lenore-taylor",
+        "apiUrl": "https://content.guardianapis.com/australia-news/audio/2021/jul/30/are-the-nsw-covid-disaster-payments-too-little-too-late-with-lenore-taylor",
+        "fields": {
+          "standfirst": "<p>As the NSW Covid outbreak continues and millions of Australians struggle to access the financial support they need, the state and federal governments have announced increased Covid support payments. Guardian Australia editor Lenore Taylor and head of news Mike Ticher discuss if this expansion of financial support has hit the mark</p>",
+          "trailText": "Guardian Australia editor Lenore Taylor and head of news Mike Ticher discuss the expansion of Covid financial support in NSW",
+          "internalPageCode": "9776795"
+        },
+        "elements": [
+          {
+            "id": "gu-audio-61024f7d8f089093df86d929",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2021/07/29-32759-fs_friday_jobsaver.mp3",
+                "typeData": {
+                  "source": "guardian",
+                  "secureFile": "https://audio.guim.co.uk/2021/07/29-32759-fs_friday_jobsaver.mp3",
+                  "sizeInBytes": "30513778",
+                  "durationMinutes": "21",
+                  "durationSeconds": "11",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "2b5ca6f9a99c487385c6b541c4a72117a134d87d",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/2b5ca6f9a99c487385c6b541c4a72117a134d87d/0_62_3916_2350/master/3916.jpg",
+                "typeData": {
+                  "altText": "NSW Treasurer Dominic Perrottet, Prime Minister Scott Morrison and NSW Premier Gladys Berejiklian",
+                  "credit": "Photograph: Mick Tsikas/AAP",
+                  "photographer": "Mick Tsikas",
+                  "source": "AAP",
+                  "width": "3916",
+                  "height": "2350",
+                  "secureFile": "https://media.guim.co.uk/2b5ca6f9a99c487385c6b541c4a72117a134d87d/0_62_3916_2350/master/3916.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "2b5ca6f9a99c487385c6b541c4a72117a134d87d",
+                  "imageType": "Photograph",
+                  "suppliersReference": "60ed24a0ed2829ad82a905dd",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/2b5ca6f9a99c487385c6b541c4a72117a134d87d"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/2b5ca6f9a99c487385c6b541c4a72117a134d87d/0_62_3916_2350/3916.jpg",
+                "typeData": {
+                  "altText": "NSW Treasurer Dominic Perrottet, Prime Minister Scott Morrison and NSW Premier Gladys Berejiklian",
+                  "credit": "Photograph: Mick Tsikas/AAP",
+                  "photographer": "Mick Tsikas",
+                  "source": "AAP",
+                  "width": "3916",
+                  "height": "2350",
+                  "secureFile": "https://media.guim.co.uk/2b5ca6f9a99c487385c6b541c4a72117a134d87d/0_62_3916_2350/3916.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "2b5ca6f9a99c487385c6b541c4a72117a134d87d",
+                  "imageType": "Photograph",
+                  "suppliersReference": "60ed24a0ed2829ad82a905dd",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/2b5ca6f9a99c487385c6b541c4a72117a134d87d"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/2b5ca6f9a99c487385c6b541c4a72117a134d87d/0_62_3916_2350/500.jpg",
+                "typeData": {
+                  "altText": "NSW Treasurer Dominic Perrottet, Prime Minister Scott Morrison and NSW Premier Gladys Berejiklian",
+                  "credit": "Photograph: Mick Tsikas/AAP",
+                  "photographer": "Mick Tsikas",
+                  "source": "AAP",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/2b5ca6f9a99c487385c6b541c4a72117a134d87d/0_62_3916_2350/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "2b5ca6f9a99c487385c6b541c4a72117a134d87d",
+                  "imageType": "Photograph",
+                  "suppliersReference": "60ed24a0ed2829ad82a905dd",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/2b5ca6f9a99c487385c6b541c4a72117a134d87d"
+                }
+              }
+            ]
+          }
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/news",
+        "pillarName": "News"
+      }
+    ],
+    "leadContent": [
+      {
+        "id": "science/audio/2014/nov/07/cern-royal-society-science-book-prize",
+        "type": "audio",
+        "sectionId": "science",
+        "webTitle": "Royal Society Winton Prize for Science Books - podcast",
+        "webPublicationDate": "2014-11-07T16:26:00Z",
+        "fields": {
+          "internalStoryPackageCode": "81198",
+          "standfirst": "Which is the best popular science book of the year? Robin McKie and Nicky Clayton discuss the six shortlisted. Plus, Rosetta's moment in space and Cern gets its new leader",
+          "trailText": "<p>The best popular science book of the year, Rosetta's moment in space and Cern's new leader</p>"
+        },
+        "webUrl": "https://www.theguardian.com/science/audio/2014/nov/07/cern-royal-society-science-book-prize",
+        "apiUrl": "https://content.guardianapis.com/science/audio/2014/nov/07/cern-royal-society-science-book-prize",
+        "sectionName": "Science",
+        "elements": [
+          {
+            "id": "gu-audio-451459946",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://static.guim.co.uk/audio/kip/science/series/science/1415315200719/128/gdn.sci.141106.ic.Science_Podcast.mp3",
+                "typeData": {
+                  "explicit": "false",
+                  "source": "guardian.co.uk",
+                  "durationMinutes": "28",
+                  "durationSeconds": "42"
+                }
+              }
+            ]
+          }
+        ],
+        "tags": [
+          {
+            "id": "science/science",
+            "webTitle": "Science",
+            "type": "keyword",
+            "sectionId": "science",
+            "webUrl": "https://www.theguardian.com/science/science",
+            "apiUrl": "https://content.guardianapis.com/science/science",
+            "sectionName": "Science"
+          },
+          {
+            "id": "science/cern",
+            "webTitle": "Cern",
+            "type": "keyword",
+            "sectionId": "science",
+            "webUrl": "https://www.theguardian.com/science/cern",
+            "apiUrl": "https://content.guardianapis.com/science/cern",
+            "sectionName": "Science"
+          },
+          {
+            "id": "books/royal-society-science-book-prize",
+            "webTitle": "Royal Society Winton Prize for Science Books",
+            "description": "The latest news and comment on the Royal Society Winton Prize for Science Books",
+            "type": "keyword",
+            "sectionId": "books",
+            "webUrl": "https://www.theguardian.com/books/royal-society-science-book-prize",
+            "apiUrl": "https://content.guardianapis.com/books/royal-society-science-book-prize",
+            "sectionName": "Books"
+          },
+          {
+            "id": "science/rosetta-space-probe",
+            "webTitle": "Rosetta space probe",
+            "description": "The latest news and comment on the Rosetta space probe",
+            "type": "keyword",
+            "sectionId": "science",
+            "webUrl": "https://www.theguardian.com/science/rosetta-space-probe",
+            "apiUrl": "https://content.guardianapis.com/science/rosetta-space-probe",
+            "sectionName": "Science"
+          },
+          {
+            "id": "science/space",
+            "webTitle": "Space",
+            "type": "keyword",
+            "sectionId": "science",
+            "webUrl": "https://www.theguardian.com/science/space",
+            "apiUrl": "https://content.guardianapis.com/science/space",
+            "sectionName": "Science"
+          },
+          {
+            "id": "science/royal-society",
+            "webTitle": "Royal Society",
+            "type": "keyword",
+            "sectionId": "science",
+            "webUrl": "https://www.theguardian.com/science/royal-society",
+            "apiUrl": "https://content.guardianapis.com/science/royal-society",
+            "sectionName": "Science"
+          },
+          {
+            "id": "books/scienceandnature",
+            "webTitle": "Science and nature",
+            "type": "keyword",
+            "sectionId": "books",
+            "webUrl": "https://www.theguardian.com/books/scienceandnature",
+            "apiUrl": "https://content.guardianapis.com/books/scienceandnature",
+            "sectionName": "Books"
+          },
+          {
+            "id": "books/books",
+            "webTitle": "Books",
+            "type": "keyword",
+            "sectionId": "books",
+            "webUrl": "https://www.theguardian.com/books/books",
+            "apiUrl": "https://content.guardianapis.com/books/books",
+            "sectionName": "Books"
+          }
+        ]
+      },
+      {
+        "id": "science/audio/2014/nov/03/chemistry-food-and-drink",
+        "type": "audio",
+        "sectionId": "science",
+        "webTitle": "The science of food and drink - podcast",
+        "webPublicationDate": "2014-11-03T07:00:00Z",
+        "fields": {
+          "standfirst": "Food author Harold McGee reveals the chemistry of cooking and what is it like to work with Heston Bluementhal. And finally we find out why James Bond prefers his Martini shaken, not stirred",
+          "internalContentCode": "450911337",
+          "trailText": "<p>Food author Harold McGee on the chemistry of cooking and working with Heston Bluementhal</p>"
+        },
+        "webUrl": "https://www.theguardian.com/science/audio/2014/nov/03/chemistry-food-and-drink",
+        "apiUrl": "https://content.guardianapis.com/science/audio/2014/nov/03/chemistry-food-and-drink",
+        "sectionName": "Science",
+        "elements": [
+          {
+            "id": "gu-audio-450911337",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://static.guim.co.uk/audio/kip/science/series/science/1414599978449/1094/gdn.141102.ic.Science_Weekly.mp3",
+                "typeData": {
+                  "explicit": "false",
+                  "source": "guardian.co.uk",
+                  "durationMinutes": "25",
+                  "durationSeconds": "22"
+                }
+              }
+            ]
+          }
+        ],
+        "tags": [
+          {
+            "id": "science/science",
+            "webTitle": "Science",
+            "type": "keyword",
+            "sectionId": "science",
+            "webUrl": "https://www.theguardian.com/science/science",
+            "apiUrl": "https://content.guardianapis.com/science/science",
+            "sectionName": "Science"
+          },
+          {
+            "id": "science/chemistry",
+            "webTitle": "Chemistry",
+            "type": "keyword",
+            "sectionId": "science",
+            "webUrl": "https://www.theguardian.com/science/chemistry",
+            "apiUrl": "https://content.guardianapis.com/science/chemistry",
+            "sectionName": "Science"
+          },
+          {
+            "id": "lifeandstyle/food-and-drink",
+            "webTitle": "Food & drink",
+            "type": "keyword",
+            "sectionId": "lifeandstyle",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/food-and-drink",
+            "apiUrl": "https://content.guardianapis.com/lifeandstyle/food-and-drink",
+            "sectionName": "Life and style"
+          },
+          {
+            "id": "lifeandstyle/lifeandstyle",
+            "webTitle": "Life and style",
+            "type": "keyword",
+            "sectionId": "lifeandstyle",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/lifeandstyle",
+            "apiUrl": "https://content.guardianapis.com/lifeandstyle/lifeandstyle",
+            "sectionName": "Life and style"
+          }
+        ]
+      },
+      {
+        "id": "science/audio/2014/jul/07/science-weekly-podcast-robbert-dijkgraaf-where-great-minds-think",
+        "type": "podcast",
+        "sectionId": "science",
+        "webTitle": "Science Weekly podcast: Robbert Dijkgraaf on where great minds can think",
+        "webPublicationDate": "2014-07-07T05:00:00Z",
+        "fields": {
+          "standfirst": "The celebrated Dutch mathematician discusses his role as director of Princeton's Institute for Advanced Studies and why, from Einstein to Chomsky, big ideas are born there",
+          "internalContentCode": "441296331",
+          "trailText": "<p>Mathematician Robbert Dijkgraaf on Einstein, Chomsky and the need for a place for great minds to think big</p>"
+        },
+        "webUrl": "https://www.theguardian.com/science/audio/2014/jul/07/science-weekly-podcast-robbert-dijkgraaf-where-great-minds-think",
+        "apiUrl": "https://content.guardianapis.com/science/audio/2014/jul/07/science-weekly-podcast-robbert-dijkgraaf-where-great-minds-think",
+        "sectionName": "Science",
+        "elements": [
+          {
+            "id": "gu-audio-441296331",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://static.guim.co.uk/audio/kip/science/series/science/1404485877366/4653/gnl.sci.140707.jp.science_weekly.mp3",
+                "typeData": {
+                  "explicit": "false",
+                  "source": "Guardian",
+                  "durationMinutes": "44",
+                  "durationSeconds": "7"
+                }
+              }
+            ]
+          }
+        ],
+        "tags": [
+          {
+            "id": "science/science",
+            "webTitle": "Science",
+            "type": "keyword",
+            "sectionId": "science",
+            "webUrl": "https://www.theguardian.com/science/science",
+            "apiUrl": "https://content.guardianapis.com/science/science",
+            "sectionName": "Science"
+          },
+          {
+            "id": "technology/robots",
+            "webTitle": "Robots",
+            "type": "keyword",
+            "sectionId": "technology",
+            "webUrl": "https://www.theguardian.com/technology/robots",
+            "apiUrl": "https://content.guardianapis.com/technology/robots",
+            "sectionName": "Technology"
+          },
+          {
+            "id": "science/mathematics",
+            "webTitle": "Mathematics",
+            "type": "keyword",
+            "sectionId": "science",
+            "webUrl": "https://www.theguardian.com/science/mathematics",
+            "apiUrl": "https://content.guardianapis.com/science/mathematics",
+            "sectionName": "Science"
+          },
+          {
+            "id": "science/alberteinstein",
+            "webTitle": "Albert Einstein",
+            "type": "keyword",
+            "sectionId": "science",
+            "webUrl": "https://www.theguardian.com/science/alberteinstein",
+            "apiUrl": "https://content.guardianapis.com/science/alberteinstein",
+            "sectionName": "Science"
+          },
+          {
+            "id": "us-news/noam-chomsky",
+            "webTitle": "Noam Chomsky",
+            "type": "keyword",
+            "sectionId": "us-news",
+            "webUrl": "https://www.theguardian.com/us-news/noam-chomsky",
+            "apiUrl": "https://content.guardianapis.com/us-news/noam-chomsky",
+            "sectionName": "US news"
+          },
+          {
+            "id": "environment/coral",
+            "webTitle": "Coral",
+            "type": "keyword",
+            "sectionId": "environment",
+            "webUrl": "https://www.theguardian.com/environment/coral",
+            "apiUrl": "https://content.guardianapis.com/environment/coral",
+            "sectionName": "Environment"
+          },
+          {
+            "id": "environment/environment",
+            "webTitle": "Environment",
+            "type": "keyword",
+            "sectionId": "environment",
+            "webUrl": "https://www.theguardian.com/environment/environment",
+            "apiUrl": "https://content.guardianapis.com/environment/environment",
+            "sectionName": "Environment"
+          },
+          {
+            "id": "environment/conservation",
+            "webTitle": "Conservation",
+            "type": "keyword",
+            "sectionId": "environment",
+            "webUrl": "https://www.theguardian.com/environment/conservation",
+            "apiUrl": "https://content.guardianapis.com/environment/conservation",
+            "sectionName": "Environment"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What does this change?

Potentially halves the CAPI response size at the cost of additional complexity.

Thrift response size for technology/series/chips-with-everything tag
show all fields: 1048576
show selected fields: 524288

## How to test

On a local machine curl the output of a podcast tag to a local file.
Apply this change, curl and diff the the files.
The XML should be the same indicating that all of the fields required to render the feed items are still present.

<img width="1667" alt="Screenshot 2021-09-01 at 09 38 42" src="https://user-images.githubusercontent.com/150238/131640864-2e122e71-aba6-4f7e-928e-90a72a80c1a6.png">


## How can we measure success?

Reduced response size; may lead to less CAPI errors at 1am if less marshalling frees up CAPI resources.

A reduction in average response time for this service's requests would be nice.


## Have we considered potential risks?

Has a field been accidentally omitted in away with subtly changes the feed output.
The composer id been a good example.


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
