### PR TITLE
Migrate generic small logo feed channel image

### DIFF
--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -59,13 +59,7 @@ object iTunesRssFeed {
             <itunes:summary>{ description }</itunes:summary>
             <image>
               <title>{ tag.webTitle }</title>
-              {
-                if (adFree) {
-                  <url>{ podcast.image.getOrElse("https://static.guim.co.uk/sitecrumbs/Guardian.gif") }</url>
-                } else {
-                  <url>https://static.guim.co.uk/sitecrumbs/Guardian.gif</url>
-                }
-              }
+              <url>{ podcast.image.getOrElse("https://static.guim.co.uk/sitecrumbs/Guardian.gif") }</url>
               <link>{ tag.webUrl }</link>
             </image>
             {

--- a/test/com/gu/itunes/ItunesRssFeedSpec.scala
+++ b/test/com/gu/itunes/ItunesRssFeedSpec.scala
@@ -39,7 +39,7 @@ class ItunesRssFeedSpec extends FlatSpec with ItunesTestData with Matchers {
           <itunes:new-feed-url>https://www.theguardian.com/science/series/science/podcast.xml</itunes:new-feed-url>
           <image>
             <title>Science Weekly</title>
-            <url>https://static.guim.co.uk/sitecrumbs/Guardian.gif</url>
+            <url>https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/4/22/1398182483649/ScienceWeekly.png</url>
             <link>https://www.theguardian.com/science/series/science</link>
           </image>
           <itunes:category text="Health">


### PR DESCRIPTION
To be the same 3000x300…0 podcast specific image as itunes:image.

While this field is no longer documented in any discoverable Apple documentation this would make our feed consistent with other large podcast publishers are retire an out of date branding usage.

This is the format requested by -large Internet company which is not Apple- and what -large publisher- does in there feeds.

<img width="711" alt="Screenshot 2021-09-01 at 22 29 48" src="https://user-images.githubusercontent.com/150238/131749037-f13ac380-4b43-445f-a866-473d48cbd764.png">



## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
