### PR TITLE
Set CAPI connect timeout. Less aggressive retries

### DIFF
--- a/app/com/gu/itunes/CustomCapiClient.scala
+++ b/app/com/gu/itunes/CustomCapiClient.scala
@@ -44,8 +44,8 @@ class CustomCapiClient(val apiKey: String) extends ContentApiClient {
 object CustomCapiClient {
 
   val http = new OkHttpClient.Builder()
-    .connectTimeout(1000, TimeUnit.SECONDS)
-    .readTimeout(2000, TimeUnit.SECONDS)
+    .connectTimeout(1, TimeUnit.SECONDS)
+    .readTimeout(2, TimeUnit.SECONDS)
     .followRedirects(true)
     .connectionPool(new ConnectionPool(10, 60, TimeUnit.SECONDS))
     .build()

--- a/app/com/gu/itunes/CustomCapiClient.scala
+++ b/app/com/gu/itunes/CustomCapiClient.scala
@@ -37,8 +37,8 @@ class CustomCapiClient(val apiKey: String) extends ContentApiClient {
   }
 
   override implicit val executor: ScheduledExecutor = ScheduledExecutor()
-  private val initialDelay = 250.millis
-  override val backoffStrategy: ContentApiBackoff = ContentApiBackoff.exponentialStrategy(initialDelay, maxAttempts = 5)
+  private val initialDelay = 1000.millis
+  override val backoffStrategy: ContentApiBackoff = ContentApiBackoff.multiplierStrategy(initialDelay, multiplier = 1.5, maxAttempts = 3)
 }
 
 object CustomCapiClient {

--- a/app/com/gu/itunes/CustomCapiClient.scala
+++ b/app/com/gu/itunes/CustomCapiClient.scala
@@ -31,7 +31,7 @@ class CustomCapiClient(val apiKey: String) extends ContentApiClient {
 
     response.future map { result =>
       val end = System.nanoTime()
-      Logger.info(s"Received CAPI response in ${Duration.fromNanos(end - start).toMillis} ms")
+      Logger.info(s"Received CAPI response ${result.statusCode} in ${Duration.fromNanos(end - start).toMillis} ms")
       result
     }
   }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,12 +1,12 @@
 package com.gu.itunes
 
-import com.gu.contentapi.client.model.{ ContentApiError, ItemQuery }
+import com.gu.contentapi.client.model.{ContentApiError, ItemQuery}
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{ DateTime, DateTimeZone }
 import org.scalactic.{ Bad, Good }
 import play.api.mvc.Results._
-import play.api.mvc.{ BaseController, ControllerComponents, Result }
-import play.api.{ Configuration, Logger }
+import play.api.mvc.{BaseController, ControllerComponents, Result}
+import play.api.{Configuration, Logger}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -28,6 +28,9 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
   private val HTTPDateFormat = DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'").withZone(DateTimeZone.UTC)
 
   def itunesRss(tagId: String, userApiKey: Option[String]) = Action.async { implicit request =>
+    val userAgent = request.headers.get("user-agent").getOrElse("")
+    Logger.info(s"Received request for tag '$tagId' from user agent '$userAgent'")
+
     val redirect = Redirection.redirect(tagId)
     redirect match {
       case Some(redirectedTagId) => Future.successful(MovedPermanently(routes.Application.itunesRss(redirectedTagId, userApiKey).absoluteURL(true)))

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -2,8 +2,8 @@ package com.gu.itunes
 
 import com.gu.contentapi.client.model.{ContentApiError, ItemQuery}
 import org.joda.time.format.DateTimeFormat
-import org.joda.time.{ DateTime, DateTimeZone }
-import org.scalactic.{ Bad, Good }
+import org.joda.time.{DateTime, DateTimeZone, Duration}
+import org.scalactic.{Bad, Good}
 import play.api.mvc.Results._
 import play.api.mvc.{BaseController, ControllerComponents, Result}
 import play.api.{Configuration, Logger}
@@ -28,14 +28,24 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
   private val HTTPDateFormat = DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'").withZone(DateTimeZone.UTC)
 
   def itunesRss(tagId: String, userApiKey: Option[String]) = Action.async { implicit request =>
+    val startTime = DateTime.now
     val userAgent = request.headers.get("user-agent").getOrElse("")
     Logger.info(s"Received request for tag '$tagId' from user agent '$userAgent'")
 
     val redirect = Redirection.redirect(tagId)
-    redirect match {
+    val eventualResult = redirect match {
       case Some(redirectedTagId) => Future.successful(MovedPermanently(routes.Application.itunesRss(redirectedTagId, userApiKey).absoluteURL(true)))
       case None =>
         rawRss(tagId, userApiKey)
+    }
+
+    eventualResult.map { result =>
+      Logger.info(s"Returning response status ${result.header.status} for tag '${tagId} after ${durationSince(startTime)}")
+      result
+    }.recover {
+      case t: Throwable =>
+        Logger.warn(s"Failed to complete for tag '$tagId after ${durationSince(startTime)}", t)
+        InternalServerError("Could not complete request")
     }
   }
 
@@ -93,4 +103,7 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
   def healthcheck = Action {
     Ok("OK")
   }
+
+  private def durationSince(time: DateTime): String = new Duration(time, DateTime.now).getMillis + "ms"
+
 }

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -1,6 +1,4 @@
 <configuration>
-    
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
 
   <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>logs/itunes-rss.log</file>
@@ -15,7 +13,7 @@
 
   <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%date %-5coloredLevel %logger - %msg%n%xException{30}</pattern>
+      <pattern>%date %logger - %msg%n%xException{30}</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
## What does this change?

General speculative tinkering without any backing evidence.

Podcasts look like they are been abit demanding with their CAPI requests.
The app is holding long running connections and retrying aggressively.


#### Fix incorrect CAPI request timeout setting
Reduce the CAPI connection timeout from 20 minutes to 2 seconds.

Podcasts were seen waiting over 10 seconds for a CAPI response during peaks.
This may be preventing us from failing fast and letting the CDN serve a stale cached response.

Additionally we may be blocking other CAPI users by holding our large requests open for long durations.

####  Be less aggressive with our retries; longer pause and less retries
We are making large expensive requests which take CAPI several seconds to response to during peaks.

To give CAPI a break our pause between retries should be a similar size to the the expected response time.

Because we are making long running requests it does not make sense to retry 5 times within a single user request.
The incoming request from the CDN will probably have timed out before we complete all our retries.


#### Log the user agent for podcast requests
If the CDN has not stripped the header this may tell us something interesting able regular bursts of podcast requests.

#### Log response time and failures.
So that we can see now the service behaves normally and have a way to see when we are failing to response.


## How to test

This works fine on a local dev machine.

## How can we measure success?

Podcast continues to response to requests.
CAPI's health during peaks may improve as this service stops holding long running requests.


## Have we considered potential risks?

We are enforcing the 2 second timeout for the first time.
Podcasts have been making large expensive CAPI requests.

It's quite possible that podcasts will not be able to complete within the new 2 second timeout.
We will be able to see this in the new failure logging if it's an issue.

BUT we consider it better for podcasts to fail early rather than letting slow podcast queries propogate into problems for other CAPI users.





## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
