### PR TITLE
itunes:block for adfree feeds moves up from item to channel level

### DIFF
--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -69,6 +69,11 @@ object iTunesRssFeed {
               <link>{ tag.webUrl }</link>
             </image>
             {
+              if (adFree) {
+                <itunes:block>yes</itunes:block>
+              }
+            }
+            {
               for (category <- podcast.categories.getOrElse(Nil)) yield new CategoryRss(category).toXml
             }
             {

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -204,11 +204,6 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
         }
       }
       <itunes:summary>{ scala.xml.Utility.escape(summary) }</itunes:summary>
-      {
-        if (adFree) {
-          <itunes:block>yes</itunes:block>
-        }
-      }
     </item>
   }
 

--- a/test/com/gu/itunes/ItunesRssFeedSpec.scala
+++ b/test/com/gu/itunes/ItunesRssFeedSpec.scala
@@ -80,6 +80,23 @@ class ItunesRssFeedSpec extends FlatSpec with ItunesTestData with Matchers {
     }
   }
 
+  it should "mark ad free podcast channels as blocked so that the are not indexed in things like Google podcasts" in {
+    // https://developers.google.com/news/assistant/your-news-update/overview
+    // To prevent the feed from public availability on products like iTunes or Google Podcasts, the value can be set to Yes (not case sensitive). Any other value has no effect.
+    val currentXml = trim(iTunesRssFeed(itunesCapiResponse, adFree = true).get)
+    println(currentXml)
+
+    val channelLevelItunesBlock = (currentXml \\ "channel" \ "block").filter(_.prefix == "itunes").head
+    channelLevelItunesBlock.text should be("yes")
+  }
+
+  it should "not prevent non ad free podcasts from been indexed" in {
+    val currentXml = trim(iTunesRssFeed(itunesCapiResponse, adFree = false).get)
+
+    val channelLevelItunesBlock = (currentXml \\ "channel" \ "block").filter(_.prefix == "itunes")
+    channelLevelItunesBlock.isEmpty should be(true)
+  }
+
   it should "not show new-feed-url tag in ad free feeds to avoid confusing robots" in {
     val currentXml = trim(iTunesRssFeed(itunesCapiResponse, adFree = true).get)
 

--- a/test/com/gu/itunes/ItunesRssFeedSpec.scala
+++ b/test/com/gu/itunes/ItunesRssFeedSpec.scala
@@ -84,7 +84,6 @@ class ItunesRssFeedSpec extends FlatSpec with ItunesTestData with Matchers {
     // https://developers.google.com/news/assistant/your-news-update/overview
     // To prevent the feed from public availability on products like iTunes or Google Podcasts, the value can be set to Yes (not case sensitive). Any other value has no effect.
     val currentXml = trim(iTunesRssFeed(itunesCapiResponse, adFree = true).get)
-    println(currentXml)
 
     val channelLevelItunesBlock = (currentXml \\ "channel" \ "block").filter(_.prefix == "itunes").head
     channelLevelItunesBlock.text should be("yes")

--- a/test/com/gu/itunes/ItunesRssItemSpec.scala
+++ b/test/com/gu/itunes/ItunesRssItemSpec.scala
@@ -94,28 +94,6 @@ class ItunesRssItemSpec extends FlatSpec with ItunesTestData with Matchers {
     result foreach (x => x._1 \ "summary" should be(x._2 \ "summary"))
   }
 
-  it should "mark ad free podcasts as blocked so that the are not indexed in things like Google podcasts" in {
-    // https://developers.google.com/news/assistant/your-news-update/overview
-    // To prevent the feed from public availability on products like iTunes or Google Podcasts, the value can be set to Yes (not case sensitive). Any other value has no effect.
-    val results = itunesCapiResponse.results.getOrElse(Nil)
-    val tagId = itunesCapiResponse.tag.get.id
-
-    val podcasts = for (p <- results) yield new iTunesRssItem(p, tagId, p.elements.get.head.assets.head, true).toXml
-
-    val firstItemsItunesBlock = (podcasts \\ "item" \ "block").filter(_.prefix == "itunes").head
-    firstItemsItunesBlock.text should be("yes")
-  }
-
-  it should "not prevent non ad free podcasts from been indexed" in {
-    val results = itunesCapiResponse.results.getOrElse(Nil)
-    val tagId = itunesCapiResponse.tag.get.id
-
-    val podcasts = for (p <- results) yield new iTunesRssItem(p, tagId, p.elements.get.head.assets.head, false).toXml
-
-    val itunesBlockTag = (podcasts \\ "item" \ "block").find(_.prefix == "itunes")
-    itunesBlockTag should be(None)
-  }
-
   it should "omit itunes:subtitle tag from ad free feeds as it is often out of spec" in {
     // Often exceeds 255 characters which is reported as a validation failure in the w3c feed validation tool.
     // Omit from ad free feeds to avoid validation rejections.


### PR DESCRIPTION
## What does this change?

itunes:block for adfree feeds moves up from item to channel level.
Requested by the syndication partner this effects.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
