### PR TITLE
Set up Acast tag for Book It In podcast

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -138,7 +138,9 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
         AcastLaunchGroup(new DateTime(2021, 9, 1, 0, 0), Seq(
           "australia-news/series/australia-reads")),
         AcastLaunchGroup(new DateTime(2021, 10, 5, 0, 0), Seq(
-          "culture/series/saved-for-later")))
+          "culture/series/saved-for-later")),
+        AcastLaunchGroup(new DateTime(2021, 12, 2, 0, 0), Seq(
+          "culture/series/book-it-in")))
 
       val useAcastProxy = !adFree && acastPodcasts.find(_.tagIds.contains(tagId)).exists(p => lastModified.isAfter(p.launchDate))
       if (useAcastProxy) "https://flex.acast.com/" + url.replace("https://", "") else url


### PR DESCRIPTION
## What does this change?

Enable the Book It In podcast for Acast pipeline

## How to test

Check for the presence of a flex wrapper on the URL after this is merged

## How can we measure success?

See above

## Have we considered potential risks?

This is an extension of an existing mechanism and should be risk-free

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
- [x] Not applicable
