### PR TITLE
Set up The Final Word Ashes podcast for Acast

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -140,7 +140,9 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
         AcastLaunchGroup(new DateTime(2021, 10, 5, 0, 0), Seq(
           "culture/series/saved-for-later")),
         AcastLaunchGroup(new DateTime(2021, 12, 2, 0, 0), Seq(
-          "culture/series/book-it-in")))
+          "culture/series/book-it-in")),
+        AcastLaunchGroup(new DateTime(2021, 12, 8, 0, 0), Seq(
+          "sport/series/the-final-word-ashes-podcast")))
 
       val useAcastProxy = !adFree && acastPodcasts.find(_.tagIds.contains(tagId)).exists(p => lastModified.isAfter(p.launchDate))
       if (useAcastProxy) "https://flex.acast.com/" + url.replace("https://", "") else url


### PR DESCRIPTION
## What does this change?

Adds the Acast wrapper for this new series tag 

## How to test

Check that the wrapper is applied correctly after merging

## How can we measure success?

Does the wrapper get applied? If yes, then success!

## Have we considered potential risks?

Very low risk from listener's perspective - the podcast will work with or without the wrapper

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
- [x] Not applicable
