### PR TITLE
Fix overlapping returned items by keeping constant page size in requests

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -63,10 +63,6 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
       .showFields("webTitle,webPublicationDate,standfirst,trailText,internalComposerCode")
 
     def fetchItemsWithPagination(query: ItemQuery, page: Int = 1, resps: Seq[ItemResponse] = Seq.empty): Future[Seq[ItemResponse]] = {
-      // The last page fetch may need to be smaller to prevent returning too many results
-      //val currentDepth = (page - 1) * pageSize
-      //val pageSizeForThisCall = Seq(maxItems - currentDepth, pageSize).min
-
       Logger.debug("Fetching page: " + page + " with page size: " + pageSize)
       val withPagination = query.page(page).pageSize(pageSize)
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -55,7 +55,7 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
     val client = new CustomCapiClient(apiKey)
 
     val maxItems = 300
-    val pageSize = 200
+    val pageSize = 100
 
     val query = ItemQuery(tagId)
       .showElements("audio")

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -64,11 +64,11 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
 
     def fetchItemsWithPagination(query: ItemQuery, page: Int = 1, resps: Seq[ItemResponse] = Seq.empty): Future[Seq[ItemResponse]] = {
       // The last page fetch may need to be smaller to prevent returning too many results
-      val currentDepth = (page - 1) * pageSize
-      val pageSizeForThisCall = Seq(maxItems - currentDepth, pageSize).min
+      //val currentDepth = (page - 1) * pageSize
+      //val pageSizeForThisCall = Seq(maxItems - currentDepth, pageSize).min
 
-      Logger.debug("Fetching page: " + page + " with page size: " + pageSizeForThisCall)
-      val withPagination = query.page(page).pageSize(pageSizeForThisCall)
+      Logger.debug("Fetching page: " + page + " with page size: " + pageSize)
+      val withPagination = query.page(page).pageSize(pageSize)
 
       client.getResponse(withPagination).flatMap { resp =>
         val responses = resps :+ resp


### PR DESCRIPTION
## What does this change?

We have added in the past a hack to return 300 items via pagination but that is using a variable page size which implies that we end up returning overlapping items (first request: page 1, pageSize = 200, returning items 1 to 200, second request: page 2, pageSize = 100, returning items 101 to 200). By keeping the pageSize constant to 100 we resolve this issue.

## How to test
We retrieve non repeating items for podcasts.

## How can we measure success?

There are no repeated podcasts being returned.
