### PR TITLE
Add flex tagging for theguardianswomensfootballweekly podcast

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -145,8 +145,10 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
           "sport/series/the-final-word-ashes-podcast")),
         AcastLaunchGroup(new DateTime(2022, 1, 31, 0, 0), Seq(
           "lifeandstyle/series/weekend")),
-          AcastLaunchGroup(new DateTime(2022, 2, 18, 0, 0), Seq(
-          "politics/series/politics-weekly-america"))
+        AcastLaunchGroup(new DateTime(2022, 2, 18, 0, 0), Seq(
+          "politics/series/politics-weekly-america")),
+        AcastLaunchGroup(new DateTime(2022, 6, 28, 0, 0), Seq(
+          "football/series/theguardianswomensfootballweekly"))
       )
 
       val useAcastProxy = !adFree && acastPodcasts.find(_.tagIds.contains(tagId)).exists(p => lastModified.isAfter(p.launchDate))


### PR DESCRIPTION
## What does this change?

Adds a new podcast to the Acast group, and set the launch date to include the trailer episode.

## How to test

Deploy and check that the trailer has the acast wrapper

## How can we measure success?

If the acast wrapper is applied... SUCCESS!

## Have we considered potential risks?

Risks are minimal. Unless the entire thing fails to build somehow.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
- [x] Not applicable
