### PR TITLE
Handle unauthorized status code

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -119,6 +119,7 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
     }).recover {
       case ContentApiError(404, _, _) => NotFound
       case ContentApiError(403, _, _) => Forbidden
+      case ContentApiError(401, _, _) => Unauthorized
       // maybe this generic InternalServerError could be a better representation of the CAPI failure mode
       case ContentApiError(status, msg, errorResponse) =>
         Logger.warn(s"Unexpected response code from CAPI. tagId = $tagId, HTTP status = $status, error response = $errorResponse")


### PR DESCRIPTION
## What does this change?

This handles the 401 unauthorized status responses from CAPI.

Why? 

The lack of a 401 handler meant that CAPI 401s where returned as 500s from itunes-rss which was detected in a `fastly-edge-cache` test failure here:

https://github.com/guardian/fastly-edge-cache/blob/cfc6feae4b609d47f466814953553aa4f61479f2/theguardiancom/src/test/scala/com/gu/PodcastIntegrationTest.scala#L20


## How to test

Run locally and make a request with an invalid api key

<img width="1007" alt="image" src="https://user-images.githubusercontent.com/74187452/196473569-643b9f6f-b466-446e-9d6c-0c64c4538153.png">


