### PR TITLE
Replace deprecated `bucket` riff-raff parameter

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
   podcasts-rss:
     type: autoscaling
     parameters:
-      bucket: content-api-dist
+      bucketSsmLookup: true
     dependencies:
       - podcasts-rss-ami-update
   podcasts-rss-ami-update:


### PR DESCRIPTION
The `bucket` parameter in riff-raff.yaml has been deprecated in favour of `bucketSsmLookup`.  This causes Riffraff to look up the destination bucket from a parameter in the AWS account's SSM parameter store instead of being hard-coded.  We are currently getting deprecation warnings when deploying this project in riffraff, and merging this PR should fix that by replacing the deprecated parameter with the new one.