### PR TITLE
Bump some dependencies and remove unnecessary overrides

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,13 +12,13 @@ val root = Project("podcasts-rss", file("."))
   .settings(
     libraryDependencies ++= Seq(
       "org.jsoup" % "jsoup" % "1.15.4",
-      "com.gu" %% "content-api-client" % "19.2.1",
-      "com.squareup.okhttp3" % "okhttp" % "4.10.0",
-      "software.amazon.awssdk" % "secretsmanager" % "2.20.69",
+      "com.gu" %% "content-api-client" % "19.4.0",
+      "com.squareup.okhttp3" % "okhttp" % "4.12.0", // SNYK-JAVA-ORGJETBRAINSKOTLIN-2393744, SNYK-JAVA-COMSQUAREUPOKIO-5820002
+      "software.amazon.awssdk" % "secretsmanager" % "2.20.162", // SNYK-JAVA-IONETTY-1042268
       "org.scalactic" %% "scalactic" % "3.2.15",
       "org.scalatest" %% "scalatest" % "3.2.15" % "test",
       "net.logstash.logback" % "logstash-logback-encoder" % "7.3",
-      "com.gu" %% "content-api-models-json" % "17.5.1" % "test",
+      "com.gu" %% "content-api-models-json" % "17.7.0" % "test",
       "com.gu" %% "simple-configuration-core" % "1.5.7",
       "com.gu.play-secret-rotation" %% "play-v28" % "0.37",
       "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "0.37",
@@ -38,18 +38,9 @@ Universal / packageName := normalizedName.value
 
 dependencyOverrides ++=Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.12.7.1",
-  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.8",
-
-  //"org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0",
-
-    "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.7",
-  "org.apache.tomcat.embed" % "tomcat-embed-core" % "8.5.86",
-  "org.apache.tomcat" % "tomcat-annotations-api" % "8.5.86",
-  "org.apache.thrift" % "libthrift" % "0.14.0",
-
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.7",
   "io.netty" % "netty-handler" % "4.1.94.Final",
-
-  "com.google.guava" % "guava" % "32.0.0-jre"
+  "io.netty" % "netty-codec-http2" % "4.1.100.Final", // SNYK-JAVA-IONETTY-5953332
 )
 
 excludeDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.20")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 


### PR DESCRIPTION
## What does this change?

Updates some dependencies and adds an override for `netty-codec-http2`. It seems we can also do away with some of the other overrides we had in place - at least as far as local testing and running suggests.

## How to test

Tested locally, all passed. Ran locally and compared the output for e.g. `news/series/the-audio-long-read/podcast.xml` side-by-side with PROD and it appeared to be identical.

If it builds and can be deployed successfully, we can test it further.

## How can we measure success?

We should see no unusual behaviour or errors, and the output should be identical between versions.

## Have we considered potential risks?

There should be very little risk here, as long as locally observed behaviour persists all the way out to production.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A (there is no UI or intended-for-human-consumption output here)
