### PR TITLE
Bump logback dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val root = Project("podcasts-rss", file("."))
       "org.scalatest" %% "scalatest" % "3.2.15" % "test",
       "net.logstash.logback" % "logstash-logback-encoder" % "7.3",
       "com.gu" %% "content-api-models-json" % "17.7.0" % "test",
-      "com.gu" %% "simple-configuration-core" % "1.5.7",
+      "com.gu" %% "simple-configuration-core" % "1.5.8",
       "com.gu.play-secret-rotation" %% "play-v28" % "0.37",
       "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "0.37",
       //AWS SDK v2 clients
@@ -41,6 +41,8 @@ dependencyOverrides ++=Seq(
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.7",
   "io.netty" % "netty-handler" % "4.1.94.Final",
   "io.netty" % "netty-codec-http2" % "4.1.100.Final", // SNYK-JAVA-IONETTY-5953332
+  "ch.qos.logback" % "logback-classic" % "1.4.12",
+  "ch.qos.logback" % "logback-core" % "1.4.12",
 )
 
 excludeDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.20")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.21")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 


### PR DESCRIPTION
## What does this change?

- bump logback for vulns
- simple-configuration-core as a patch was available
- SBT just because

## How to test

Run it up, check it's working and logging

## How can we measure success?

Fixes alerts
