### PR TITLE
fix high vuln logback (now to 1.4.14).

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,8 +41,7 @@ dependencyOverrides ++=Seq(
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.7",
   "io.netty" % "netty-handler" % "4.1.94.Final",
   "io.netty" % "netty-codec-http2" % "4.1.100.Final", // SNYK-JAVA-IONETTY-5953332
-  "ch.qos.logback" % "logback-classic" % "1.4.12",
-  "ch.qos.logback" % "logback-core" % "1.4.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.14",
 )
 
 excludeDependencies ++= Seq(


### PR DESCRIPTION
## What does this change?

Snyk has again reported high vulns for logback dependency, this time we need to upgrade its patch version to 14. (so now to 1.4.14)

## How to test

sbt test
snyk test
running locally

## How can we measure success?

test should pass
running locally should be as expected.
snyk test should have no high vulns listed