### PR TITLE
Add flex url for black box podcast

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -160,7 +160,10 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
         AcastLaunchGroup(new DateTime(2022, 10, 28, 0, 0), Seq(
           "news/series/australia-v-the-climate")),
         AcastLaunchGroup(new DateTime(2023, 3, 28, 0, 0), Seq(
-          "news/series/cotton-capital-podcast")))
+          "news/series/cotton-capital-podcast")),
+        AcastLaunchGroup(new DateTime(2024, 2, 15, 0, 0), Seq(
+          "technology/series/blackbox"))
+      )
 
       val useAcastProxy = !adFree && acastPodcasts.find(_.tagIds.contains(tagId)).exists(p => lastModified.isAfter(p.launchDate))
       if (useAcastProxy) "https://flex.acast.com/" + url.replace("https://", "") else url


### PR DESCRIPTION
Requested by Gabriel Smith this morning:

> We have a new podcast, please can you add flex URLs and send the message to Acast to enable to new podcast series in the logs? 
> 
> Black Box
> https://www.theguardian.com/technology/series/blackbox
> https://www.theguardian.com/technology/series/blackbox/podcast.xml

First item in the podcast seems to have been posted yesterday based on [the podcast page](https://www.theguardian.com/technology/series/blackbox), so I’ve chosen yesterday as the date.

I think this is all that’s required, based on [the PR I found that Rowanne made last time](https://github.com/guardian/itunes-rss/pull/141), but I’ll have a look around for other changes around the same time.