### PR TITLE
Bump All The Things and see what happens

### DIFF
--- a/app/com/gu/itunes/DateSupport.scala
+++ b/app/com/gu/itunes/DateSupport.scala
@@ -1,6 +1,6 @@
 package com.gu.itunes
 
-import org.joda.time.{ DateTimeZone, DateTime }
+import org.joda.time.{ DateTime, DateTimeZone }
 import org.joda.time.format.DateTimeFormat
 
 object DateSupport {

--- a/build.sbt
+++ b/build.sbt
@@ -11,19 +11,19 @@ val root = Project("podcasts-rss", file("."))
   .enablePlugins(PlayScala, JavaServerAppPackaging, SystemdPlugin)
   .settings(
     libraryDependencies ++= Seq(
-      "org.jsoup" % "jsoup" % "1.15.4",
-      "com.gu" %% "content-api-client" % "19.4.0",
+      "org.jsoup" % "jsoup" % "1.17.2",
+      "com.gu" %% "content-api-client" % "26.0.0",
       "com.squareup.okhttp3" % "okhttp" % "4.12.0", // SNYK-JAVA-ORGJETBRAINSKOTLIN-2393744, SNYK-JAVA-COMSQUAREUPOKIO-5820002
-      "software.amazon.awssdk" % "secretsmanager" % "2.20.162", // SNYK-JAVA-IONETTY-1042268
-      "org.scalactic" %% "scalactic" % "3.2.15",
-      "org.scalatest" %% "scalatest" % "3.2.15" % "test",
-      "net.logstash.logback" % "logstash-logback-encoder" % "7.3",
-      "com.gu" %% "content-api-models-json" % "17.7.0" % "test",
-      "com.gu" %% "simple-configuration-core" % "1.5.8",
-      "com.gu.play-secret-rotation" %% "play-v28" % "0.37",
-      "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "0.37",
+      "software.amazon.awssdk" % "secretsmanager" % "2.25.32", // SNYK-JAVA-IONETTY-1042268
+      "org.scalactic" %% "scalactic" % "3.2.18",
+      "org.scalatest" %% "scalatest" % "3.2.18" % "test",
+      "net.logstash.logback" % "logstash-logback-encoder" % "7.4",
+      "com.gu" %% "content-api-models-json" % "23.0.0" % "test", // keeping in line with imports from content-api-client
+      "com.gu" %% "simple-configuration-core" % "2.0.0",
+      "com.gu.play-secret-rotation" %% "play-v28" % "8.2.1",
+      "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "8.2.1",
       //AWS SDK v2 clients
-      "software.amazon.awssdk" % "url-connection-client" % "2.20.68", //only used at startup. For operations we use akka http client
+      "software.amazon.awssdk" % "url-connection-client" % "2.25.32", //only used at startup. For operations we use akka http client
     ),
     maintainer := "Guardian Content Platforms <content-platforms.dev@theguardian.com>",
     version := "1.0",
@@ -39,8 +39,8 @@ Universal / packageName := normalizedName.value
 dependencyOverrides ++=Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.12.7.1",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.7",
-  "io.netty" % "netty-handler" % "4.1.94.Final",
-  "io.netty" % "netty-codec-http2" % "4.1.100.Final", // SNYK-JAVA-IONETTY-5953332
+//  "io.netty" % "netty-handler" % "4.1.94.Final",
+//  "io.netty" % "netty-codec-http2" % "4.1.100.Final", // SNYK-JAVA-IONETTY-5953332
   "ch.qos.logback" % "logback-classic" % "1.4.14",
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,10 +20,11 @@ val root = Project("podcasts-rss", file("."))
       "net.logstash.logback" % "logstash-logback-encoder" % "7.4",
       "com.gu" %% "content-api-models-json" % "23.0.0" % "test", // keeping in line with imports from content-api-client
       "com.gu" %% "simple-configuration-core" % "2.0.0",
-      "com.gu.play-secret-rotation" %% "play-v28" % "8.2.1",
+      "com.gu.play-secret-rotation" %% "play-v30" % "8.2.1",
       "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "8.2.1",
       //AWS SDK v2 clients
       "software.amazon.awssdk" % "url-connection-client" % "2.25.32", //only used at startup. For operations we use akka http client
+      "joda-time" % "joda-time" % "2.12.7"
     ),
     maintainer := "Guardian Content Platforms <content-platforms.dev@theguardian.com>",
     version := "1.0",
@@ -37,11 +38,8 @@ val root = Project("podcasts-rss", file("."))
 Universal / packageName := normalizedName.value
 
 dependencyOverrides ++=Seq(
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.12.7.1",
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.7",
-//  "io.netty" % "netty-handler" % "4.1.94.Final",
-//  "io.netty" % "netty-codec-http2" % "4.1.100.Final", // SNYK-JAVA-IONETTY-5953332
-  "ch.qos.logback" % "logback-classic" % "1.4.14",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.3",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.14.3"
 )
 
 excludeDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.21")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 


### PR DESCRIPTION
## What does this change?

Bumps as many dependency versions as we can currently get. Also removes a couple of `io.netty` overrides, so we'll see how that shapes up.

## How to test

Run locally, check the output side-by-side with PROD. At first glance it looks identical.

## How can we measure success?

If it doesn't break, I'll take that as a success, but will check for ongoing dependency issues anyway.

## Have we considered potential risks?

If it breaks, we redeploy the previous `main` build and then revert this PR or fix forwards, depending on the nature and severity of the failure.

## Images

**PROD (left) vs this branch (right):**
<img width="1919" alt="Screenshot 2024-04-17 at 15 58 48" src="https://github.com/guardian/itunes-rss/assets/690395/e2d08f7c-5def-4065-84a1-0925f2991748">

<img width="1919" alt="Screenshot 2024-04-17 at 15 59 21" src="https://github.com/guardian/itunes-rss/assets/690395/e933d3e1-187d-4de8-8d9c-4a57923aeb79">

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
