### PR TITLE
Use fastly-resizer image URLs for specific podcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ You need to export an env variable `API_KEY`:
 $ export API_KEY="some-internal-tier-key"
 ```
 
+and an AWS region:
+
+```
+$export AWS_REGION=eu-west-1
+```
+
+and a fastly signature salt:
+
+```
+$export FASTLY_SALT=astringthatactuallyworkswillbeneeded
+```
+
 then
 
 ```

--- a/app/com/gu/itunes/SecretKeeper.scala
+++ b/app/com/gu/itunes/SecretKeeper.scala
@@ -64,10 +64,11 @@ object SecretKeeper {
     // In the event we can't load the signature salt, or we load
     // an empty value, this shouldn't crash the application.
     // Instead we just suppress the generation of episodic artwork
-    // images if we determine that the salt is NONE or an empty string
+    // images if we determine that the salt is NONE (or an empty
+    // string which we treat as NONE)
     case Success(result) if result == "" =>
       logger.warn("Loaded the fastly image resizer signature salt but it was an empty string")
-      Some(result)
+      None
     case Failure(err) =>
       logger.warn(s"Could not load Fastly image resizer signature salt: ${err.getMessage}")
       None
@@ -87,7 +88,7 @@ object SecretKeeper {
       fromConfig
     case fromConfig @ Some(sigSalt) if sigSalt == "" =>
       logger.warn("Loaded the fastly image resizer signature salt from configuration but it was an empty string")
-      fromConfig
+      None
     case _ =>
       loadFastlySignatureSaltFromSecretsManager()
   }

--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -39,17 +39,17 @@ object iTunesRssFeed {
     afterChange ++ beforeChange.take(100)
   }
 
-  def apply(resps: Seq[ItemResponse], adFree: Boolean = false): Node Or Failed = {
+  def apply(resps: Seq[ItemResponse], adFree: Boolean = false, imageResizerSalt: String): Node Or Failed = {
     val tag = resps.headOption.flatMap(_.tag)
     tag match {
       case Some(t) =>
         val content = resps.flatMap(_.results.getOrElse(Nil)).toList
-        toXml(t, appleExcessDownloadsWorkaround(content), adFree)
+        toXml(t, appleExcessDownloadsWorkaround(content), adFree, imageResizerSalt)
       case None => Bad(Failed("tag not found", NotFound))
     }
   }
 
-  def toXml(tag: Tag, contents: List[Content], adFree: Boolean): Node Or Failed = {
+  def toXml(tag: Tag, contents: List[Content], adFree: Boolean, imageResizerSalt: String): Node Or Failed = {
 
     val description = Filtering.description(tag.description.getOrElse(""))
 
@@ -106,7 +106,7 @@ object iTunesRssFeed {
               for {
                 podcastContent <- contents
                 asset <- getFirstAudioAsset(podcastContent)
-              } yield new iTunesRssItem(podcastContent, tag.id, asset, adFree, podcast.podcastType).toXml
+              } yield new iTunesRssItem(podcastContent, tag.id, asset, adFree, podcast.podcastType, imageResizerSalt).toXml
             }
           </channel>
         </rss>

--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -39,7 +39,7 @@ object iTunesRssFeed {
     afterChange ++ beforeChange.take(100)
   }
 
-  def apply(resps: Seq[ItemResponse], adFree: Boolean = false, imageResizerSalt: String): Node Or Failed = {
+  def apply(resps: Seq[ItemResponse], adFree: Boolean = false, imageResizerSalt: Option[String]): Node Or Failed = {
     val tag = resps.headOption.flatMap(_.tag)
     tag match {
       case Some(t) =>
@@ -49,7 +49,7 @@ object iTunesRssFeed {
     }
   }
 
-  def toXml(tag: Tag, contents: List[Content], adFree: Boolean, imageResizerSalt: String): Node Or Failed = {
+  def toXml(tag: Tag, contents: List[Content], adFree: Boolean, imageResizerSalt: Option[String]): Node Or Failed = {
 
     val description = Filtering.description(tag.description.getOrElse(""))
 

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -13,8 +13,8 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
   private val standfirstOrTrail = podcast.fields.flatMap(_.standfirst) orElse trailText
 
   private def isValidForEpisodicArtwork(podcast: Content): Boolean = {
-    tagId == "australia-news/series/full-story" &&
-      podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2024, 5, 7, 0, 0).getMillis)
+    tagId == "lifeandstyle/series/comforteatingwithgracedent" &&
+      podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2024, 6, 11, 0, 0).getMillis)
   }
 
   def toXml: Node = {

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -227,7 +227,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
 
     val summary = Filtering.standfirst(standfirstOrTrail.getOrElse("")) + membershipCta
 
-    val episodeImage: Option[String] = if (isValidForEpisodicArtwork(podcast) && imageResizerSignatureSalt.exists(_.nonEmpty)) {
+    val episodeImage: Option[String] = imageResizerSignatureSalt.filter(_.nonEmpty && isValidForEpisodicArtwork(podcast)).flatMap { salt =>
       val maybeThumbnailImageElements = podcast.elements.find(_.exists(el => el.relation == "thumbnail" && el.`type` == ElementType.Image))
         .getOrElse(Seq.empty)
       val assets = maybeThumbnailImageElements.flatMap { el =>
@@ -240,7 +240,6 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
       val maxDim = 3000 // we're going for square crops, so width will always == height anyway
       val quality = 75 // reads like a compression limiter (rather than dpi)
       val fit = "crop" // automatically crop from the centre of the original
-      val salt = imageResizerSignatureSalt.get // we know it exists(_.nonEmpty) at this point, so get is safe
 
       assets.headOption.flatMap { asset =>
         asset.file.map { filePath =>
@@ -255,8 +254,6 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
           imageUri
         }
       }
-    } else {
-      None
     }
 
     <item>

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -30,6 +30,9 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
   val cacheControl = s"max-age=$maxAge, stale-while-revalidate=$staleWhileRevalidateSeconds, stale-if-error=$oneDayInSeconds"
   private val HTTPDateFormat = DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'").withZone(DateTimeZone.UTC)
 
+  private val imageResizerSignatureSalt: String = SecretKeeper.getImageResizerSignatureSalt(config).
+    getOrElse(sys.error("No image signature salt is configured!"))
+
   def itunesRss(tagId: String, userApiKey: Option[String]) = Action.async { implicit request =>
     val startTime = DateTime.now
     val userAgent = request.headers.get("user-agent").getOrElse("")
@@ -59,7 +62,7 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
     val pageSize = 100
 
     val query = ItemQuery(tagId)
-      .showElements("audio")
+      .showElements("audio,image")
       .showTags("keyword")
       .showFields("webTitle,webPublicationDate,standfirst,trailText,internalComposerCode")
 
@@ -98,7 +101,7 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
       // If all item responses were ok then we can render a result
       if (itemResponses.forall(_.status == "ok")) {
         val isAdFree = userApiKeyTier.contains("rights-managed")
-        iTunesRssFeed(itemResponses, isAdFree) match {
+        iTunesRssFeed(itemResponses, isAdFree, imageResizerSignatureSalt) match {
           case Good(xml) =>
             val now = DateTime.now()
             val expiresTime = now.plusSeconds(maxAge)

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -30,8 +30,7 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
   val cacheControl = s"max-age=$maxAge, stale-while-revalidate=$staleWhileRevalidateSeconds, stale-if-error=$oneDayInSeconds"
   private val HTTPDateFormat = DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'").withZone(DateTimeZone.UTC)
 
-  private val imageResizerSignatureSalt: String = SecretKeeper.getImageResizerSignatureSalt(config).
-    getOrElse(sys.error("No image signature salt is configured!"))
+  private val imageResizerSignatureSalt: Option[String] = SecretKeeper.getImageResizerSignatureSalt(config)
 
   def itunesRss(tagId: String, userApiKey: Option[String]) = Action.async { implicit request =>
     val startTime = DateTime.now

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -5,5 +5,6 @@ play.i18n.langs = [ "en" ]
 # apiKey is going to be overwritten by an $API_KEY env variable, if present or loaded from Secrets Manager
 apiKey = ""
 apiKey = ${?API_KEY}
-
+fastlyImageResizerSignatureSalt = ""
+fastlyImageResizerSignatureSalt = ${?FASTLY_SALT}
 pidfile.path = "/dev/null"

--- a/test/com/gu/itunes/AcastProxySpec.scala
+++ b/test/com/gu/itunes/AcastProxySpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers
 
 class AcastProxySpec extends AnyFlatSpec with Matchers with ItunesTestData {
 
-  private val imageResizerSalt = Some("TBA")
+  private val imageResizerSalt: Option[String] = None
 
   val testContent: Seq[Content] = itunesCapiResponseAcastTest.results.get.toSeq
   val tag: String = itunesCapiResponseAcastTest.tag.get.id

--- a/test/com/gu/itunes/AcastProxySpec.scala
+++ b/test/com/gu/itunes/AcastProxySpec.scala
@@ -6,20 +6,22 @@ import org.scalatest.matchers.should.Matchers
 
 class AcastProxySpec extends AnyFlatSpec with Matchers with ItunesTestData {
 
+  private val imageResizerSalt = "TBA"
+
   val testContent: Seq[Content] = itunesCapiResponseAcastTest.results.get.toSeq
   val tag: String = itunesCapiResponseAcastTest.tag.get.id
 
   it should "use the acast proxy" in {
     val newItem: Content = testContent.head
     val asset: Asset = testContent.head.elements.head.head.assets.find(_.`type` == AssetType.Audio).get
-    val item = new iTunesRssItem(newItem, tag, asset)
+    val item = new iTunesRssItem(newItem, tag, asset, imageResizerSignatureSalt = imageResizerSalt)
     (item.toXml.head \\ "enclosure" \ "@url").text shouldBe "https://flex.acast.com/audio.guim.co.uk/2017/05/30-51066-gnl.rs.brexit.20170530.thelastbeforethelection.mp3"
   }
 
   it should "use Guardian origin" in {
     val oldItem: Content = testContent(1)
     val asset: Asset = testContent(1).elements.head.head.assets.find(_.`type` == AssetType.Audio).get
-    val item = new iTunesRssItem(oldItem, tag, asset)
+    val item = new iTunesRssItem(oldItem, tag, asset, imageResizerSignatureSalt = imageResizerSalt)
     (item.toXml.head \\ "enclosure" \ "@url").text shouldBe "https://audio.guim.co.uk/2017/05/24-54013-gnl.rs.brexit.20170524.negotiationsguidelines.mp3"
   }
 

--- a/test/com/gu/itunes/AcastProxySpec.scala
+++ b/test/com/gu/itunes/AcastProxySpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers
 
 class AcastProxySpec extends AnyFlatSpec with Matchers with ItunesTestData {
 
-  private val imageResizerSalt = "TBA"
+  private val imageResizerSalt = Some("TBA")
 
   val testContent: Seq[Content] = itunesCapiResponseAcastTest.results.get.toSeq
   val tag: String = itunesCapiResponseAcastTest.tag.get.id

--- a/test/com/gu/itunes/ItunesRssFeedSpec.scala
+++ b/test/com/gu/itunes/ItunesRssFeedSpec.scala
@@ -10,9 +10,11 @@ import org.scalatest.matchers.should.Matchers
 
 class ItunesRssFeedSpec extends AnyFlatSpec with ItunesTestData with Matchers {
 
+  private val imageResizerSalt = "TBA"
+
   it should "check that the produced XML for the tags is consistent" in {
 
-    val currentXml = trim(iTunesRssFeed(Seq(itunesCapiResponse)).get)
+    val currentXml = trim(iTunesRssFeed(Seq(itunesCapiResponse), imageResizerSalt = imageResizerSalt).get)
 
     val expectedXml = trim(
       <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
@@ -70,7 +72,7 @@ class ItunesRssFeedSpec extends AnyFlatSpec with ItunesTestData with Matchers {
   }
 
   it should "return a 404 if a podcast cannot be found" in {
-    val attempt = Try(iTunesRssFeed(Seq(tagMissingPodcastFieldResponse)))
+    val attempt = Try(iTunesRssFeed(Seq(tagMissingPodcastFieldResponse), imageResizerSalt = imageResizerSalt))
     attempt.get match {
       case Bad(failed: Failed) =>
         failed.message should be("podcast not found")
@@ -84,28 +86,28 @@ class ItunesRssFeedSpec extends AnyFlatSpec with ItunesTestData with Matchers {
   it should "mark ad free podcast channels as blocked so that the are not indexed in things like Google podcasts" in {
     // https://developers.google.com/news/assistant/your-news-update/overview
     // To prevent the feed from public availability on products like iTunes or Google Podcasts, the value can be set to Yes (not case sensitive). Any other value has no effect.
-    val currentXml = trim(iTunesRssFeed(Seq(itunesCapiResponse), adFree = true).get)
+    val currentXml = trim(iTunesRssFeed(Seq(itunesCapiResponse), adFree = true, imageResizerSalt = imageResizerSalt).get)
 
     val channelLevelItunesBlock = (currentXml \\ "channel" \ "block").filter(_.prefix == "itunes").head
     channelLevelItunesBlock.text should be("yes")
   }
 
   it should "not prevent non ad free podcasts from been indexed" in {
-    val currentXml = trim(iTunesRssFeed(Seq(itunesCapiResponse), adFree = false).get)
+    val currentXml = trim(iTunesRssFeed(Seq(itunesCapiResponse), adFree = false, imageResizerSalt = imageResizerSalt).get)
 
     val channelLevelItunesBlock = (currentXml \\ "channel" \ "block").filter(_.prefix == "itunes")
     channelLevelItunesBlock.isEmpty should be(true)
   }
 
   it should "not show new-feed-url tag in ad free feeds to avoid confusing robots" in {
-    val currentXml = trim(iTunesRssFeed(Seq(itunesCapiResponse), adFree = true).get)
+    val currentXml = trim(iTunesRssFeed(Seq(itunesCapiResponse), adFree = true, imageResizerSalt = imageResizerSalt).get)
 
     val itunesNewFeedUrl = (currentXml \\ "channel" \ "new-feed-url").find(_.prefix == "itunes")
     itunesNewFeedUrl should be(None)
   }
 
   it should "show large image specific to this podcast on the channel image tag for ad free feeds" in {
-    val currentXml = trim(iTunesRssFeed(Seq(itunesCapiResponse), adFree = true).get)
+    val currentXml = trim(iTunesRssFeed(Seq(itunesCapiResponse), adFree = true, imageResizerSalt = imageResizerSalt).get)
 
     val channelImageUrl = currentXml \\ "channel" \ "image" \ "url"
 

--- a/test/com/gu/itunes/ItunesRssFeedSpec.scala
+++ b/test/com/gu/itunes/ItunesRssFeedSpec.scala
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 
 class ItunesRssFeedSpec extends AnyFlatSpec with ItunesTestData with Matchers {
 
-  private val imageResizerSalt = "TBA"
+  private val imageResizerSalt = Some("TBA")
 
   it should "check that the produced XML for the tags is consistent" in {
 

--- a/test/com/gu/itunes/ItunesRssFeedSpec.scala
+++ b/test/com/gu/itunes/ItunesRssFeedSpec.scala
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 
 class ItunesRssFeedSpec extends AnyFlatSpec with ItunesTestData with Matchers {
 
-  private val imageResizerSalt = Some("TBA")
+  private val imageResizerSalt: Option[String] = None
 
   it should "check that the produced XML for the tags is consistent" in {
 

--- a/test/com/gu/itunes/ItunesRssItemSpec.scala
+++ b/test/com/gu/itunes/ItunesRssItemSpec.scala
@@ -9,11 +9,13 @@ import org.scalatest.OptionValues
 
 class ItunesRssItemSpec extends AnyFlatSpec with ItunesTestData with Matchers with OptionValues {
 
+  val imageResizerSalt = "TBA"
+
   it should "check that the produced XML for the podcasts is consistent" in {
 
     val results = itunesCapiResponse.results.getOrElse(Nil)
     val tagId = itunesCapiResponse.tag.get.id
-    val podcasts = for (p <- results) yield new iTunesRssItem(p, tagId, p.elements.get.head.assets.head, adFree = false).toXml
+    val podcasts = for (p <- results) yield new iTunesRssItem(p, tagId, p.elements.get.head.assets.head, adFree = false, imageResizerSignatureSalt = imageResizerSalt).toXml
     val trimmedPodcasts = for (p <- podcasts) yield trim(p)
 
     val expectedXml = RemoveWhitespace.transform(
@@ -107,7 +109,7 @@ class ItunesRssItemSpec extends AnyFlatSpec with ItunesTestData with Matchers wi
     val results = itunesCapiResponse.results.getOrElse(Nil)
     val tagId = itunesCapiResponse.tag.get.id
 
-    val podcasts = for (p <- results) yield new iTunesRssItem(p, tagId, p.elements.get.head.assets.head, true).toXml
+    val podcasts = for (p <- results) yield new iTunesRssItem(p, tagId, p.elements.get.head.assets.head, true, imageResizerSignatureSalt = imageResizerSalt).toXml
 
     val firstItemSubtitleTag = (podcasts \\ "item" \ "subtitle").find(_.prefix == "itunes")
     firstItemSubtitleTag should be(None)
@@ -117,7 +119,7 @@ class ItunesRssItemSpec extends AnyFlatSpec with ItunesTestData with Matchers wi
     val results = itunesCapiResponse.results.getOrElse(Nil)
     val tagId = itunesCapiResponse.tag.get.id
 
-    val podcasts = for (p <- results) yield new iTunesRssItem(p, tagId, p.elements.get.head.assets.head, false).toXml
+    val podcasts = for (p <- results) yield new iTunesRssItem(p, tagId, p.elements.get.head.assets.head, false, imageResizerSignatureSalt = imageResizerSalt).toXml
 
     val itemSubtitleTags = (podcasts \\ "item" \ "subtitle").filter(_.prefix == "itunes")
     itemSubtitleTags.lastOption.map(_.text) should be(Some("Guardian Australia editor Lenore Taylor and head of news Mike Ticher discuss the expansion of Covid financial support in NSW"))
@@ -128,7 +130,7 @@ class ItunesRssItemSpec extends AnyFlatSpec with ItunesTestData with Matchers wi
     tag.podcast.value.podcastType.value should be("serial")
     val result = itunesCapiResponseEpisodeNumber.results.get.head
     val rssItem = new iTunesRssItem(result, tag.id, result.elements.get.head.assets.head, false,
-      tag.podcast.value.podcastType).toXml
+      tag.podcast.value.podcastType, imageResizerSignatureSalt = imageResizerSalt).toXml
     val episodeTag = (rssItem \ "episode").head
     episodeTag.prefix should be("itunes")
     episodeTag.text should be("6")
@@ -140,7 +142,7 @@ class ItunesRssItemSpec extends AnyFlatSpec with ItunesTestData with Matchers wi
     val tag = itunesCapiResponseNoType.tag.get
     val result = itunesCapiResponseEpisodeNumber.results.get.head
     val rssItem = new iTunesRssItem(result, tag.id, result.elements.get.head.assets.head, false,
-      tag.podcast.value.podcastType).toXml
+      tag.podcast.value.podcastType, imageResizerSignatureSalt = imageResizerSalt).toXml
     (rssItem \ "episode") shouldBe empty
   }
 
@@ -148,7 +150,7 @@ class ItunesRssItemSpec extends AnyFlatSpec with ItunesTestData with Matchers wi
     val tag = itunesCapiResponse.tag.get
     val result = itunesCapiResponse.results.get.head
     val rssItem = new iTunesRssItem(result, tag.id, result.elements.get.head.assets.head, false,
-      tag.podcast.value.podcastType).toXml
+      tag.podcast.value.podcastType, imageResizerSignatureSalt = imageResizerSalt).toXml
     (rssItem \ "episode") shouldBe empty
   }
 }

--- a/test/com/gu/itunes/ItunesRssItemSpec.scala
+++ b/test/com/gu/itunes/ItunesRssItemSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.OptionValues
 
 class ItunesRssItemSpec extends AnyFlatSpec with ItunesTestData with Matchers with OptionValues {
 
-  val imageResizerSalt = Some("abcdefabcdefabcdef")
+  val imageResizerSalt: Option[String] = Some("abcdefabcdefabcdef")
 
   it should "check that the produced XML for the podcasts is consistent" in {
 
@@ -199,6 +199,8 @@ class ItunesRssItemSpec extends AnyFlatSpec with ItunesTestData with Matchers wi
   }
 
   it should "not add episodic artwork if the fastly salt is defined as an empty string" in {
+    // this shouldn't happen naturally but if iTunesRssItem.episodeImage is ever changed
+    // and allows the salt param through as an empty string this test should start failing
     val tag = itunesCapiResponseFullStory.tag.get
     val emptyResizerSalt: Option[String] = Some("")
     val resultWithEpisodicImage = itunesCapiResponseFullStory.results.get.head

--- a/test/com/gu/itunes/ItunesRssItemSpec.scala
+++ b/test/com/gu/itunes/ItunesRssItemSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.OptionValues
 
 class ItunesRssItemSpec extends AnyFlatSpec with ItunesTestData with Matchers with OptionValues {
 
-  val imageResizerSalt = "abcdefabcdefabcdef"
+  val imageResizerSalt = Some("abcdefabcdefabcdef")
 
   it should "check that the produced XML for the podcasts is consistent" in {
 
@@ -179,8 +179,37 @@ class ItunesRssItemSpec extends AnyFlatSpec with ItunesTestData with Matchers wi
     val expectedGuid = "66331a978f08cb0a1ccaaa62"
     val actualGuid = (rssItem \ "guid").head.text
     actualGuid shouldBe (expectedGuid)
-    rssItem should not be (null)
     val itunesImages = (rssItem \\ "image")
+    itunesImages.size shouldBe (0)
+  }
+
+  it should "not add episodic artwork if there is no fastly salt defined" in {
+    val tag = itunesCapiResponseFullStory.tag.get
+    val noneResizerSalt: Option[String] = None
+    val resultWithEpisodicImage = itunesCapiResponseFullStory.results.get.head
+    val rssItemWithEpisodicImage = new iTunesRssItem(resultWithEpisodicImage, tag.id, resultWithEpisodicImage.elements.get.head.assets.head, false,
+      tag.podcast.value.podcastType, imageResizerSignatureSalt = noneResizerSalt).toXml
+    // make sure we have the expected item!
+    val expectedGuid = "6639b49c8f082c8a32eab7d2"
+    val actualGuid = (rssItemWithEpisodicImage \ "guid").head.text
+    actualGuid shouldBe (expectedGuid)
+    // now check our image exists
+    val itunesImages = (rssItemWithEpisodicImage \\ "image")
+    itunesImages.size shouldBe (0)
+  }
+
+  it should "not add episodic artwork if the fastly salt is defined as an empty string" in {
+    val tag = itunesCapiResponseFullStory.tag.get
+    val emptyResizerSalt: Option[String] = Some("")
+    val resultWithEpisodicImage = itunesCapiResponseFullStory.results.get.head
+    val rssItemWithEpisodicImage = new iTunesRssItem(resultWithEpisodicImage, tag.id, resultWithEpisodicImage.elements.get.head.assets.head, false,
+      tag.podcast.value.podcastType, imageResizerSignatureSalt = emptyResizerSalt).toXml
+    // make sure we have the expected item!
+    val expectedGuid = "6639b49c8f082c8a32eab7d2"
+    val actualGuid = (rssItemWithEpisodicImage \ "guid").head.text
+    actualGuid shouldBe (expectedGuid)
+    // now check our image exists
+    val itunesImages = (rssItemWithEpisodicImage \\ "image")
     itunesImages.size shouldBe (0)
   }
 

--- a/test/com/gu/itunes/ItunesRssItemSpec.scala
+++ b/test/com/gu/itunes/ItunesRssItemSpec.scala
@@ -155,28 +155,28 @@ class ItunesRssItemSpec extends AnyFlatSpec with ItunesTestData with Matchers wi
   }
 
   it should "add episodic artwork where appropriate" in {
-    val tag = itunesCapiResponseFullStory.tag.get
-    val resultWithEpisodicImage = itunesCapiResponseFullStory.results.get.head
+    val tag = itunesCapiResponseComfortEating.tag.get
+    val resultWithEpisodicImage = itunesCapiResponseComfortEating.results.get.head
     val rssItemWithEpisodicImage = new iTunesRssItem(resultWithEpisodicImage, tag.id, resultWithEpisodicImage.elements.get.head.assets.head, false,
       tag.podcast.value.podcastType, imageResizerSignatureSalt = imageResizerSalt).toXml
     // make sure we have the expected item!
-    val expectedGuid = "6639b49c8f082c8a32eab7d2"
+    val expectedGuid = "66168c368f085cc6169111c5"
     val actualGuid = (rssItemWithEpisodicImage \ "guid").head.text
     actualGuid shouldBe (expectedGuid)
     // now check our image exists
     val itunesImages = (rssItemWithEpisodicImage \\ "image")
     itunesImages.size shouldBe (1)
-    val expectedImage = "<itunes:image>https://i.guim.co.uk/img/media/343fe14156e38ef3c019e86d48fe259ada017e5a/0_209_4965_2980/4965.jpg?width=3000&amp;height=3000&amp;quality=75&amp;fit=crop&amp;s=db30bbd54f69d1216cda0593a95f784f</itunes:image>"
+    val expectedImage = "<itunes:image>https://i.guim.co.uk/img/media/39f24967bf11d6a8298201d29e7f7a3b7e0517b8/0_0_2999_1800/2999.jpg?width=3000&amp;height=3000&amp;quality=75&amp;fit=crop&amp;s=c14d895fa1e69eeff7948fe06f7c4c01</itunes:image>"
     itunesImages.head.toString() shouldBe (expectedImage)
   }
 
   it should "not add episodic artwork where not appropriate" in {
-    val tag = itunesCapiResponseFullStory.tag.get
-    val content = itunesCapiResponseFullStory.results.map(_.drop(3).head).head
+    val tag = itunesCapiResponseComfortEating.tag.get
+    val content = itunesCapiResponseComfortEating.results.map(_.drop(3).head).head
     val rssItem = new iTunesRssItem(content, tag.id, content.elements.get.head.assets.head, false,
       tag.podcast.value.podcastType, imageResizerSignatureSalt = imageResizerSalt).toXml
     // make sure we have the expected item!
-    val expectedGuid = "66331a978f08cb0a1ccaaa62"
+    val expectedGuid = "65fd51098f0872bcdbfc1d5d"
     val actualGuid = (rssItem \ "guid").head.text
     actualGuid shouldBe (expectedGuid)
     val itunesImages = (rssItem \\ "image")
@@ -184,13 +184,13 @@ class ItunesRssItemSpec extends AnyFlatSpec with ItunesTestData with Matchers wi
   }
 
   it should "not add episodic artwork if there is no fastly salt defined" in {
-    val tag = itunesCapiResponseFullStory.tag.get
+    val tag = itunesCapiResponseComfortEating.tag.get
     val noneResizerSalt: Option[String] = None
-    val resultWithEpisodicImage = itunesCapiResponseFullStory.results.get.head
+    val resultWithEpisodicImage = itunesCapiResponseComfortEating.results.get.head
     val rssItemWithEpisodicImage = new iTunesRssItem(resultWithEpisodicImage, tag.id, resultWithEpisodicImage.elements.get.head.assets.head, false,
       tag.podcast.value.podcastType, imageResizerSignatureSalt = noneResizerSalt).toXml
     // make sure we have the expected item!
-    val expectedGuid = "6639b49c8f082c8a32eab7d2"
+    val expectedGuid = "66168c368f085cc6169111c5"
     val actualGuid = (rssItemWithEpisodicImage \ "guid").head.text
     actualGuid shouldBe (expectedGuid)
     // now check our image exists
@@ -201,13 +201,13 @@ class ItunesRssItemSpec extends AnyFlatSpec with ItunesTestData with Matchers wi
   it should "not add episodic artwork if the fastly salt is defined as an empty string" in {
     // this shouldn't happen naturally but if iTunesRssItem.episodeImage is ever changed
     // and allows the salt param through as an empty string this test should start failing
-    val tag = itunesCapiResponseFullStory.tag.get
+    val tag = itunesCapiResponseComfortEating.tag.get
     val emptyResizerSalt: Option[String] = Some("")
-    val resultWithEpisodicImage = itunesCapiResponseFullStory.results.get.head
+    val resultWithEpisodicImage = itunesCapiResponseComfortEating.results.get.head
     val rssItemWithEpisodicImage = new iTunesRssItem(resultWithEpisodicImage, tag.id, resultWithEpisodicImage.elements.get.head.assets.head, false,
       tag.podcast.value.podcastType, imageResizerSignatureSalt = emptyResizerSalt).toXml
     // make sure we have the expected item!
-    val expectedGuid = "6639b49c8f082c8a32eab7d2"
+    val expectedGuid = "66168c368f085cc6169111c5"
     val actualGuid = (rssItemWithEpisodicImage \ "guid").head.text
     actualGuid shouldBe (expectedGuid)
     // now check our image exists

--- a/test/com/gu/itunes/ItunesTestData.scala
+++ b/test/com/gu/itunes/ItunesTestData.scala
@@ -47,6 +47,10 @@ trait ItunesTestData {
     parseJson[ItemResponse](json)
   }
 
+  val itunesCapiResponseFullStory: ItemResponse = {
+    val json = loadJson("itunes-capi-full-story-response.json")
+    parseJson[ItemResponse](json)
+  }
 }
 
 object JsonHelpers {

--- a/test/com/gu/itunes/ItunesTestData.scala
+++ b/test/com/gu/itunes/ItunesTestData.scala
@@ -47,10 +47,17 @@ trait ItunesTestData {
     parseJson[ItemResponse](json)
   }
 
-  val itunesCapiResponseFullStory: ItemResponse = {
-    val json = loadJson("itunes-capi-full-story-response.json")
+  // TODO reinstate when Full Story episodes need images
+  //  val itunesCapiResponseFullStory: ItemResponse = {
+  //    val json = loadJson("itunes-capi-full-story-response.json")
+  //    parseJson[ItemResponse](json)
+  //  }
+
+  val itunesCapiResponseComfortEating: ItemResponse = {
+    val json = loadJson("itunes-capi-comfort-eating-response.json")
     parseJson[ItemResponse](json)
   }
+
 }
 
 object JsonHelpers {

--- a/test/resources/itunes-capi-comfort-eating-response.json
+++ b/test/resources/itunes-capi-comfort-eating-response.json
@@ -1,0 +1,2069 @@
+{
+  "response": {
+    "status": "ok",
+    "userTier": "internal",
+    "total": 77,
+    "startIndex": 1,
+    "pageSize": 5,
+    "currentPage": 1,
+    "pages": 16,
+    "orderBy": "newest",
+    "tag": {
+      "id": "lifeandstyle/series/comforteatingwithgracedent",
+      "type": "series",
+      "sectionId": "lifeandstyle",
+      "sectionName": "Life and style",
+      "webTitle": "Comfort Eating with Grace Dent",
+      "webUrl": "https://www.theguardian.com/lifeandstyle/series/comforteatingwithgracedent",
+      "apiUrl": "https://content.guardianapis.com/lifeandstyle/series/comforteatingwithgracedent",
+      "description": "<p>From school dinners to sofa snacks – food has a huge part to play in shaping our story – and your favourite celebs have some delicious tales to tell. <b>Join Guardian food critic and her celebrity guests, as she throws the cupboard doors open and chats life through food.</b></p><p><br></p><p>Grace’s new Comfort Eating book, inspired by the podcast, is out now. It’s a wonderfully scrumptious, life-affirming journey through the foods that really mean the most to us.</p><p><br></p><p>On the podcast, expect to hear from guests (actors from TV, movie, theatre and film; sportspeople, comedians, chefs …) such as: <i>Shirley Ballas, Nadiya Hussain, James Norton, Graham Norton, Michael Ball, Alfie Boe, Amma Asante, Gaz Coombes, Georgia Pritchett, Jayde Adams, Adam Kay, Jaime Winstone, Jay Blades, Malorie Blackman, Dawn O’Porter, Jamie Laing, Natalie Cassidy, Neneh Cherry, Greg Rutherford, Goldie, Dame Tanni Grey-Thompson, Marian Keyes, Rufus Wainwright, Saoirse-Monica Jackson, Big Zuu, Eddie Marsan, Self Esteem, James May, Guy Garvey, Dave Myers, Jo Brand, Craig David, Fern Brady, Bernardine Evaristo, Tom Watson, Rosie Jones, Laura Whitmore, Desiree Burch, Russell Tovey, Stephen Fry, Deborah Meaden, Munya Chawawa, Aisling Bea, Krishnan Guru-Murthy, Candice Carty-Williams, Lawrence Chaney, Siobhán McSweeney, Scarlett Moffatt, Mae Martin, Rafe Spall, Nish Kumar, Jon Ronson, Jamie Demetriou, Bridget Christie, Mary McCartney, Keith Brymer Jones, Adjoa Andoh, Tamsin Greig, Tom Kerridge, Suranne Jones and Russell T Davies.</i></p><p><br></p><p>Comfort Eating is a one-to-one interview. In Grace’s kitchen, her guests discuss their lives in the context of food, cooking and cuisine. They talk about comfort food and snack recipes.&nbsp;</p><p><br></p><p><i>The tone of the podcast is: warm, comforting, chatty, feel good, cheering, heart warming, comical and amusing. It’s inspiring but also escapism. It’s funny, laugh out loud, entertaining, humourous, inspirational, hilarious, illuminating, memorable, uplifting, soothing, reassuring, cheery and entertaining. Expect to hear discussion, gossip and revelation.</i></p>",
+      "podcast": {
+        "linkUrl": " ",
+        "copyright": "© 2024 Guardian News & Media Limited or its affiliated companies. All rights reserved. ",
+        "author": "theguardian.com",
+        "subscriptionUrl": "https://podcasts.apple.com/gb/podcast/comfort-eating-with-grace-dent/id1571446706",
+        "explicit": false,
+        "image": "https://uploads.guim.co.uk/2023/09/18/GD_ComfortEating_3000x3000.jpg",
+        "categories": [
+          {
+            "main": "Arts",
+            "sub": "Food"
+          }
+        ],
+        "googlePodcastsUrl": "https://www.google.com/podcasts?feed=aHR0cHM6Ly93d3cudGhlZ3VhcmRpYW4uY29tL2xpZmVhbmRzdHlsZS9zZXJpZXMvY29tZm9ydGVhdGluZ3dpdGhncmFjZWRlbnQvcG9kY2FzdC54bWw%3D",
+        "spotifyUrl": "https://open.spotify.com/show/5fMtMMKSlUoDuxhd3a3IS0?si=3B38GpeFThy4YtxSyNxApA&dl_branch=1"
+      },
+      "internalName": "Comfort Eating with Grace Dent (PODCAST ONLY)"
+    },
+    "results": [
+      {
+        "id": "lifeandstyle/audio/2024/apr/16/s6-ep-10-kiell-smith-bynoe-actor-and-comedian",
+        "type": "audio",
+        "sectionId": "lifeandstyle",
+        "sectionName": "Life and style",
+        "webPublicationDate": "2024-06-11T04:00:31Z",
+        "webTitle": "S6, Ep 10: Kiell Smith-Bynoe, actor and comedian",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/audio/2024/apr/16/s6-ep-10-kiell-smith-bynoe-actor-and-comedian",
+        "apiUrl": "https://content.guardianapis.com/lifeandstyle/audio/2024/apr/16/s6-ep-10-kiell-smith-bynoe-actor-and-comedian",
+        "fields": {
+          "standfirst": "<p>Joining Grace this week is the multi-talented actor, comedian and rapper, Kiell Smith-Bynoe. Long before becoming a household name as the exasperated boyfriend in the hit series Ghosts, Kiell (AKA MC Klayze Flaymz) tells Grace how, as a teenager, he combined his performance skills in the ultimate London arena: the chicken shop. With the taste of success, Kiell and Grace chat about his journey to the stage and screen, via several years working in a call centre for unemployed actors. Answering the big question: what is an appropriate lunchtime meal to eat at your desk?</p>",
+          "trailText": "Joining Grace this week is the multi-talented actor, comedian and rapper, Kiell Smith-Bynoe.",
+          "internalComposerCode": "66168c368f085cc6169111c5"
+        },
+        "tags": [
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://content.guardianapis.com/food/food",
+            "references": [],
+            "internalName": "Food"
+          },
+          {
+            "id": "culture/comedy",
+            "type": "keyword",
+            "sectionId": "culture",
+            "sectionName": "Culture",
+            "webTitle": "Comedy",
+            "webUrl": "https://www.theguardian.com/culture/comedy",
+            "apiUrl": "https://content.guardianapis.com/culture/comedy",
+            "references": [],
+            "internalName": "Comedy (culture)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-66168c368f085cc6169111c5",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/04/10-46586-gdn.ce.20240416.ds.Kiell_Smith_Bynoe.mp3",
+                "typeData": {
+                  "source": "The Guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/04/10-46586-gdn.ce.20240416.ds.Kiell_Smith_Bynoe.mp3",
+                  "sizeInBytes": "60490342",
+                  "durationMinutes": "39",
+                  "durationSeconds": "24",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "39f24967bf11d6a8298201d29e7f7a3b7e0517b8",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/39f24967bf11d6a8298201d29e7f7a3b7e0517b8/0_0_2999_1800/master/2999.jpg",
+                "typeData": {
+                  "altText": "Kiell Smith-Bynoe and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/39f24967bf11d6a8298201d29e7f7a3b7e0517b8/0_0_2999_1800/master/2999.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "39f24967bf11d6a8298201d29e7f7a3b7e0517b8",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/39f24967bf11d6a8298201d29e7f7a3b7e0517b8"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/39f24967bf11d6a8298201d29e7f7a3b7e0517b8/0_0_2999_1800/2999.jpg",
+                "typeData": {
+                  "altText": "Kiell Smith-Bynoe and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/39f24967bf11d6a8298201d29e7f7a3b7e0517b8/0_0_2999_1800/2999.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "39f24967bf11d6a8298201d29e7f7a3b7e0517b8",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/39f24967bf11d6a8298201d29e7f7a3b7e0517b8"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/39f24967bf11d6a8298201d29e7f7a3b7e0517b8/0_0_2999_1800/500.jpg",
+                "typeData": {
+                  "altText": "Kiell Smith-Bynoe and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/39f24967bf11d6a8298201d29e7f7a3b7e0517b8/0_0_2999_1800/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "39f24967bf11d6a8298201d29e7f7a3b7e0517b8",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/39f24967bf11d6a8298201d29e7f7a3b7e0517b8"
+                }
+              }
+            ]
+          }
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle"
+      },
+      {
+        "id": "lifeandstyle/audio/2024/apr/09/s6-ep-9-kiri-pritchard-mclean-comedian",
+        "type": "audio",
+        "sectionId": "lifeandstyle",
+        "sectionName": "Life and style",
+        "webPublicationDate": "2024-04-09T04:00:43Z",
+        "webTitle": "S6, Ep 9: Kiri Pritchard-McLean, comedian",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/audio/2024/apr/09/s6-ep-9-kiri-pritchard-mclean-comedian",
+        "apiUrl": "https://content.guardianapis.com/lifeandstyle/audio/2024/apr/09/s6-ep-9-kiri-pritchard-mclean-comedian",
+        "fields": {
+          "standfirst": "<p>Welsh standup, podcast host and panel show queen, Kiri Pritchard-McLean, brings her finest bowl of scran to Grace’s house. Over this steaming ultra-value concoction, she reveals how her upbringing on a Welsh sheep farm led to a hankering for performance, humour and cheap noodles. Cutting her teeth on the Manchester comedy circuit and finding solace with fellow newbies, Kiri learned to win in an industry still steeped in sexism. </p><p>Her latest solo show, Peacock, is about the unlikely subject of becoming a foster parent – a journey Kiri and her partner have recently embarked on. Their offering to children centres around home-cooked food made with love. Comfort eating just took on a whole new meaning.</p>",
+          "trailText": "Welsh standup, podcast host and panel show queen Kiri Pritchard-McLean brings her finest bowl of scran to Grace’s house",
+          "internalComposerCode": "660fbe9e8f085621a68051ba"
+        },
+        "tags": [
+          {
+            "id": "stage/kiri-pritchard-mclean",
+            "type": "keyword",
+            "sectionId": "stage",
+            "sectionName": "Stage",
+            "webTitle": "Kiri Pritchard-McLean",
+            "webUrl": "https://www.theguardian.com/stage/kiri-pritchard-mclean",
+            "apiUrl": "https://content.guardianapis.com/stage/kiri-pritchard-mclean",
+            "references": [],
+            "internalName": "Kiri Pritchard-McLean"
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://content.guardianapis.com/food/food",
+            "references": [],
+            "internalName": "Food"
+          },
+          {
+            "id": "culture/comedy",
+            "type": "keyword",
+            "sectionId": "culture",
+            "sectionName": "Culture",
+            "webTitle": "Comedy",
+            "webUrl": "https://www.theguardian.com/culture/comedy",
+            "apiUrl": "https://content.guardianapis.com/culture/comedy",
+            "references": [],
+            "internalName": "Comedy (culture)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-660fbe9e8f085621a68051ba",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/04/05-33781-gdn.CE.20240409.ds.Kiri_Pritchard_McLean.mp3",
+                "typeData": {
+                  "source": "The Guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/04/05-33781-gdn.CE.20240409.ds.Kiri_Pritchard_McLean.mp3",
+                  "sizeInBytes": "61276263",
+                  "durationMinutes": "39",
+                  "durationSeconds": "56",
+                  "embedType": "audio",
+                  "explicit": "true",
+                  "clean": "false"
+                }
+              }
+            ]
+          },
+          {
+            "id": "7ea748d4d3b681e71b4ba673d390f2268aa587ff",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/7ea748d4d3b681e71b4ba673d390f2268aa587ff/0_0_3000_1800/master/3000.jpg",
+                "typeData": {
+                  "altText": "Kiri Pritchard-McLean and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "3000",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/7ea748d4d3b681e71b4ba673d390f2268aa587ff/0_0_3000_1800/master/3000.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "7ea748d4d3b681e71b4ba673d390f2268aa587ff",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/7ea748d4d3b681e71b4ba673d390f2268aa587ff"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/7ea748d4d3b681e71b4ba673d390f2268aa587ff/0_0_3000_1800/3000.jpg",
+                "typeData": {
+                  "altText": "Kiri Pritchard-McLean and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "3000",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/7ea748d4d3b681e71b4ba673d390f2268aa587ff/0_0_3000_1800/3000.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "7ea748d4d3b681e71b4ba673d390f2268aa587ff",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/7ea748d4d3b681e71b4ba673d390f2268aa587ff"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/7ea748d4d3b681e71b4ba673d390f2268aa587ff/0_0_3000_1800/500.jpg",
+                "typeData": {
+                  "altText": "Kiri Pritchard-McLean and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/7ea748d4d3b681e71b4ba673d390f2268aa587ff/0_0_3000_1800/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "7ea748d4d3b681e71b4ba673d390f2268aa587ff",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/7ea748d4d3b681e71b4ba673d390f2268aa587ff"
+                }
+              }
+            ]
+          }
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle"
+      },
+      {
+        "id": "lifeandstyle/audio/2024/apr/02/s6-ep-8-tom-kerridge-chef",
+        "type": "audio",
+        "sectionId": "lifeandstyle",
+        "sectionName": "Life and style",
+        "webPublicationDate": "2024-04-02T04:00:29Z",
+        "webTitle": "S6, Ep 8: Tom Kerridge, chef",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/audio/2024/apr/02/s6-ep-8-tom-kerridge-chef",
+        "apiUrl": "https://content.guardianapis.com/lifeandstyle/audio/2024/apr/02/s6-ep-8-tom-kerridge-chef",
+        "fields": {
+          "standfirst": "<p>Comfort Eating’s culinary standards might have been permanently raised after two-Michelin-star chef Tom Kerridge’s visit. But he’s not exactly one to show off. Growing up in Gloucester, Tom always wanted to recreate the homely meals he’d find at his local pub or at his mum’s on Sundays.</p><p>With a brief detour on to the acting stage, Tom started his career working at some of the country’s top restaurants. In the rock’n’roll era of fine dining, suddenly it was cool to be working in a restaurant late at night.</p><p>But as Tom and Grace discuss, a world of late hours and excess triggered multiple health problems for him. Going sober and solo, Tom started running his own businesses and success quickly followed. So what exactly does a top chef snack on when they’re not winning awards? You might be surprised …</p>",
+          "trailText": "Grace welcomes two-Michelin-star chef Tom Kerridge to her living room this week to talk fine-dining, going sober, and of course … what snacks keep him going",
+          "internalComposerCode": "66054a488f087a4188961062"
+        },
+        "tags": [
+          {
+            "id": "food/tom-kerridge",
+            "type": "keyword",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Tom Kerridge",
+            "webUrl": "https://www.theguardian.com/food/tom-kerridge",
+            "apiUrl": "https://content.guardianapis.com/food/tom-kerridge",
+            "references": [],
+            "internalName": "Tom Kerridge (chef)"
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://content.guardianapis.com/food/food",
+            "references": [],
+            "internalName": "Food"
+          },
+          {
+            "id": "lifeandstyle/lifeandstyle",
+            "type": "keyword",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life and style",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/lifeandstyle",
+            "apiUrl": "https://content.guardianapis.com/lifeandstyle/lifeandstyle",
+            "references": [],
+            "internalName": "Life and style"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-66054a488f087a4188961062",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/03/28-49047-gdn.ce.20240402.ds.Tom_Kerridge.mp3",
+                "typeData": {
+                  "secureFile": "https://audio.guim.co.uk/2024/03/28-49047-gdn.ce.20240402.ds.Tom_Kerridge.mp3",
+                  "sizeInBytes": "63054063",
+                  "durationMinutes": "41",
+                  "durationSeconds": "10",
+                  "embedType": "audio"
+                }
+              }
+            ]
+          },
+          {
+            "id": "e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9/0_0_2999_1800/master/2999.jpg",
+                "typeData": {
+                  "altText": "Tom Kerridge and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9/0_0_2999_1800/master/2999.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9/0_0_2999_1800/2999.jpg",
+                "typeData": {
+                  "altText": "Tom Kerridge and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9/0_0_2999_1800/2999.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9/0_0_2999_1800/500.jpg",
+                "typeData": {
+                  "altText": "Tom Kerridge and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9/0_0_2999_1800/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9"
+                }
+              }
+            ]
+          }
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle"
+      },
+      {
+        "id": "lifeandstyle/audio/2024/mar/26/s6-ep-7-cat-burns-singer",
+        "type": "audio",
+        "sectionId": "lifeandstyle",
+        "sectionName": "Life and style",
+        "webPublicationDate": "2024-03-26T05:00:22Z",
+        "webTitle": "S6 Ep 7: Cat Burns, singer",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/audio/2024/mar/26/s6-ep-7-cat-burns-singer",
+        "apiUrl": "https://content.guardianapis.com/lifeandstyle/audio/2024/mar/26/s6-ep-7-cat-burns-singer",
+        "fields": {
+          "standfirst": "<p>Platinum-selling singer songwriter Cat Burns cosies up with Grace for a warm plate of nosh and some deep chats. The biggest-selling British female artist of 2022, who won three Brit award nominations after her single Go went viral on TikTok, reveals how she went from shy schoolgirl to stadium gigs in just a few years. While Covid put an end to busking on the South Bank, it opened up another portal on social channels that sent Cat’s star on its rapid ascent.</p><p>Recently diagnosed as autistic, Cat explains how her relationship with food thrives on predictability and consistency. Yet with a small recipe suggestion from her girlfriend, she had a lightbulb moment – opening up new possibilities. Cat says she doesn’t do small talk, which is more than OK; her big talk is just beautiful.</p>",
+          "trailText": "Platinum-selling singer songwriter Cat Burns cosies up with Grace for a warm plate of nosh and some deep chats",
+          "internalComposerCode": "65fd51098f0872bcdbfc1d5d"
+        },
+        "tags": [
+          {
+            "id": "music/music",
+            "type": "keyword",
+            "sectionId": "music",
+            "sectionName": "Music",
+            "webTitle": "Music",
+            "webUrl": "https://www.theguardian.com/music/music",
+            "apiUrl": "https://content.guardianapis.com/music/music",
+            "references": [],
+            "internalName": "Music"
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://content.guardianapis.com/food/food",
+            "references": [],
+            "internalName": "Food"
+          },
+          {
+            "id": "culture/culture",
+            "type": "keyword",
+            "sectionId": "culture",
+            "sectionName": "Culture",
+            "webTitle": "Culture",
+            "webUrl": "https://www.theguardian.com/culture/culture",
+            "apiUrl": "https://content.guardianapis.com/culture/culture",
+            "references": [],
+            "internalName": "Culture"
+          },
+          {
+            "id": "society/autism",
+            "type": "keyword",
+            "sectionId": "society",
+            "sectionName": "Society",
+            "webTitle": "Autism",
+            "webUrl": "https://www.theguardian.com/society/autism",
+            "apiUrl": "https://content.guardianapis.com/society/autism",
+            "references": [],
+            "internalName": "Autism (Society)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-65fd51098f0872bcdbfc1d5d",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/03/25-32938-gdn.ce.20240326.ds.Cat_Burns.mp3",
+                "typeData": {
+                  "source": "The Guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/03/25-32938-gdn.ce.20240326.ds.Cat_Burns.mp3",
+                  "sizeInBytes": "63423971",
+                  "durationMinutes": "41",
+                  "durationSeconds": "26",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "384a2ee74f6c35dc7197ec9191bcec093f5f2322",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/384a2ee74f6c35dc7197ec9191bcec093f5f2322/0_0_2999_1800/master/2999.jpg",
+                "typeData": {
+                  "altText": "Cat Burns and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/384a2ee74f6c35dc7197ec9191bcec093f5f2322/0_0_2999_1800/master/2999.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "384a2ee74f6c35dc7197ec9191bcec093f5f2322",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/384a2ee74f6c35dc7197ec9191bcec093f5f2322"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/384a2ee74f6c35dc7197ec9191bcec093f5f2322/0_0_2999_1800/2999.jpg",
+                "typeData": {
+                  "altText": "Cat Burns and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/384a2ee74f6c35dc7197ec9191bcec093f5f2322/0_0_2999_1800/2999.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "384a2ee74f6c35dc7197ec9191bcec093f5f2322",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/384a2ee74f6c35dc7197ec9191bcec093f5f2322"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/384a2ee74f6c35dc7197ec9191bcec093f5f2322/0_0_2999_1800/500.jpg",
+                "typeData": {
+                  "altText": "Cat Burns and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/384a2ee74f6c35dc7197ec9191bcec093f5f2322/0_0_2999_1800/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "384a2ee74f6c35dc7197ec9191bcec093f5f2322",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/384a2ee74f6c35dc7197ec9191bcec093f5f2322"
+                }
+              }
+            ]
+          }
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle"
+      },
+      {
+        "id": "lifeandstyle/audio/2024/mar/19/s6-ep-6-daniel-foxx-playwright",
+        "type": "audio",
+        "sectionId": "lifeandstyle",
+        "sectionName": "Life and style",
+        "webPublicationDate": "2024-03-19T05:00:23Z",
+        "webTitle": "S6 Ep 6: Daniel Foxx, comedian",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/audio/2024/mar/19/s6-ep-6-daniel-foxx-playwright",
+        "apiUrl": "https://content.guardianapis.com/lifeandstyle/audio/2024/mar/19/s6-ep-6-daniel-foxx-playwright",
+        "fields": {
+          "standfirst": "<p>Sliding into Grace’s sitting room this week is rising star and multitalented comedian, playwright and musical theatre creator, Daniel Foxx. Bringing his concoction of gunk meant only for solo consumption in the small hours, there’s nowhere left to hide. Buckle up and join Grace and Daniel as they go on a tour of the ins and outs of life in the fast lane – or is that the M6 at 1am?</p><p>Daniel shares his different incarnations – from coming out age 11 to donning a string of pearls post-lockdown. His observational obsessions have helped to feed his viral hit The Supervillain’s Gay Assistant and Grace and Daniel unpick its threads with scurrilous delight. Oh, and there’s a modern-day love story involving Tinder and trains. Scoop it all up with love and a crunchy lentil curl</p>",
+          "trailText": "Buckle up and join Grace and Daniel as they go on a tour of the ins and outs of life in the fast lane – or is that the M6 at 1am?",
+          "internalComposerCode": "65f183a08f0836980f1afdec"
+        },
+        "tags": [
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://content.guardianapis.com/food/food",
+            "references": [],
+            "internalName": "Food"
+          },
+          {
+            "id": "stage/theatre",
+            "type": "keyword",
+            "sectionId": "stage",
+            "sectionName": "Stage",
+            "webTitle": "Theatre",
+            "webUrl": "https://www.theguardian.com/stage/theatre",
+            "apiUrl": "https://content.guardianapis.com/stage/theatre",
+            "references": [],
+            "internalName": "Theatre"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-65f183a08f0836980f1afdec",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/03/13-42841-gdn.ce.20240319.ds.Foxx_Daniel.mp3",
+                "typeData": {
+                  "source": "The Guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/03/13-42841-gdn.ce.20240319.ds.Foxx_Daniel.mp3",
+                  "sizeInBytes": "69577821",
+                  "durationMinutes": "45",
+                  "durationSeconds": "42",
+                  "embedType": "audio",
+                  "explicit": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "62da4337f2f88cababe9cfd7e8f7467c4c17fd98",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/62da4337f2f88cababe9cfd7e8f7467c4c17fd98/0_0_3000_1800/master/3000.jpg",
+                "typeData": {
+                  "altText": "Daniel Fox and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "3000",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/62da4337f2f88cababe9cfd7e8f7467c4c17fd98/0_0_3000_1800/master/3000.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "62da4337f2f88cababe9cfd7e8f7467c4c17fd98",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/62da4337f2f88cababe9cfd7e8f7467c4c17fd98"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/62da4337f2f88cababe9cfd7e8f7467c4c17fd98/0_0_3000_1800/3000.jpg",
+                "typeData": {
+                  "altText": "Daniel Fox and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "3000",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/62da4337f2f88cababe9cfd7e8f7467c4c17fd98/0_0_3000_1800/3000.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "62da4337f2f88cababe9cfd7e8f7467c4c17fd98",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/62da4337f2f88cababe9cfd7e8f7467c4c17fd98"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/62da4337f2f88cababe9cfd7e8f7467c4c17fd98/0_0_3000_1800/500.jpg",
+                "typeData": {
+                  "altText": "Daniel Fox and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/62da4337f2f88cababe9cfd7e8f7467c4c17fd98/0_0_3000_1800/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "62da4337f2f88cababe9cfd7e8f7467c4c17fd98",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/62da4337f2f88cababe9cfd7e8f7467c4c17fd98"
+                }
+              }
+            ]
+          }
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle"
+      }
+    ],
+    "leadContent": [
+      {
+        "id": "lifeandstyle/audio/2024/apr/16/s6-ep-10-kiell-smith-bynoe-actor-and-comedian",
+        "type": "audio",
+        "sectionId": "lifeandstyle",
+        "sectionName": "Life and style",
+        "webPublicationDate": "2024-04-16T04:00:31Z",
+        "webTitle": "S6, Ep 10: Kiell Smith-Bynoe, actor and comedian",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/audio/2024/apr/16/s6-ep-10-kiell-smith-bynoe-actor-and-comedian",
+        "apiUrl": "https://content.guardianapis.com/lifeandstyle/audio/2024/apr/16/s6-ep-10-kiell-smith-bynoe-actor-and-comedian",
+        "fields": {
+          "standfirst": "<p>Joining Grace this week is the multi-talented actor, comedian and rapper, Kiell Smith-Bynoe. Long before becoming a household name as the exasperated boyfriend in the hit series Ghosts, Kiell (AKA MC Klayze Flaymz) tells Grace how, as a teenager, he combined his performance skills in the ultimate London arena: the chicken shop. With the taste of success, Kiell and Grace chat about his journey to the stage and screen, via several years working in a call centre for unemployed actors. Answering the big question: what is an appropriate lunchtime meal to eat at your desk?</p>",
+          "trailText": "Joining Grace this week is the multi-talented actor, comedian and rapper, Kiell Smith-Bynoe.",
+          "internalComposerCode": "66168c368f085cc6169111c5"
+        },
+        "tags": [
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://content.guardianapis.com/food/food",
+            "references": [],
+            "internalName": "Food"
+          },
+          {
+            "id": "culture/comedy",
+            "type": "keyword",
+            "sectionId": "culture",
+            "sectionName": "Culture",
+            "webTitle": "Comedy",
+            "webUrl": "https://www.theguardian.com/culture/comedy",
+            "apiUrl": "https://content.guardianapis.com/culture/comedy",
+            "references": [],
+            "internalName": "Comedy (culture)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-66168c368f085cc6169111c5",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/04/10-46586-gdn.ce.20240416.ds.Kiell_Smith_Bynoe.mp3",
+                "typeData": {
+                  "source": "The Guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/04/10-46586-gdn.ce.20240416.ds.Kiell_Smith_Bynoe.mp3",
+                  "sizeInBytes": "60490342",
+                  "durationMinutes": "39",
+                  "durationSeconds": "24",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "39f24967bf11d6a8298201d29e7f7a3b7e0517b8",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/39f24967bf11d6a8298201d29e7f7a3b7e0517b8/0_0_2999_1800/master/2999.jpg",
+                "typeData": {
+                  "altText": "Kiell Smith-Bynoe and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/39f24967bf11d6a8298201d29e7f7a3b7e0517b8/0_0_2999_1800/master/2999.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "39f24967bf11d6a8298201d29e7f7a3b7e0517b8",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/39f24967bf11d6a8298201d29e7f7a3b7e0517b8"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/39f24967bf11d6a8298201d29e7f7a3b7e0517b8/0_0_2999_1800/2999.jpg",
+                "typeData": {
+                  "altText": "Kiell Smith-Bynoe and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/39f24967bf11d6a8298201d29e7f7a3b7e0517b8/0_0_2999_1800/2999.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "39f24967bf11d6a8298201d29e7f7a3b7e0517b8",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/39f24967bf11d6a8298201d29e7f7a3b7e0517b8"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/39f24967bf11d6a8298201d29e7f7a3b7e0517b8/0_0_2999_1800/500.jpg",
+                "typeData": {
+                  "altText": "Kiell Smith-Bynoe and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/39f24967bf11d6a8298201d29e7f7a3b7e0517b8/0_0_2999_1800/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "39f24967bf11d6a8298201d29e7f7a3b7e0517b8",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/39f24967bf11d6a8298201d29e7f7a3b7e0517b8"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle"
+      },
+      {
+        "id": "lifeandstyle/audio/2024/apr/09/s6-ep-9-kiri-pritchard-mclean-comedian",
+        "type": "audio",
+        "sectionId": "lifeandstyle",
+        "sectionName": "Life and style",
+        "webPublicationDate": "2024-04-09T04:00:43Z",
+        "webTitle": "S6, Ep 9: Kiri Pritchard-McLean, comedian",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/audio/2024/apr/09/s6-ep-9-kiri-pritchard-mclean-comedian",
+        "apiUrl": "https://content.guardianapis.com/lifeandstyle/audio/2024/apr/09/s6-ep-9-kiri-pritchard-mclean-comedian",
+        "fields": {
+          "standfirst": "<p>Welsh standup, podcast host and panel show queen, Kiri Pritchard-McLean, brings her finest bowl of scran to Grace’s house. Over this steaming ultra-value concoction, she reveals how her upbringing on a Welsh sheep farm led to a hankering for performance, humour and cheap noodles. Cutting her teeth on the Manchester comedy circuit and finding solace with fellow newbies, Kiri learned to win in an industry still steeped in sexism. </p><p>Her latest solo show, Peacock, is about the unlikely subject of becoming a foster parent – a journey Kiri and her partner have recently embarked on. Their offering to children centres around home-cooked food made with love. Comfort eating just took on a whole new meaning.</p>",
+          "trailText": "Welsh standup, podcast host and panel show queen Kiri Pritchard-McLean brings her finest bowl of scran to Grace’s house",
+          "internalComposerCode": "660fbe9e8f085621a68051ba"
+        },
+        "tags": [
+          {
+            "id": "stage/kiri-pritchard-mclean",
+            "type": "keyword",
+            "sectionId": "stage",
+            "sectionName": "Stage",
+            "webTitle": "Kiri Pritchard-McLean",
+            "webUrl": "https://www.theguardian.com/stage/kiri-pritchard-mclean",
+            "apiUrl": "https://content.guardianapis.com/stage/kiri-pritchard-mclean",
+            "references": [],
+            "internalName": "Kiri Pritchard-McLean"
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://content.guardianapis.com/food/food",
+            "references": [],
+            "internalName": "Food"
+          },
+          {
+            "id": "culture/comedy",
+            "type": "keyword",
+            "sectionId": "culture",
+            "sectionName": "Culture",
+            "webTitle": "Comedy",
+            "webUrl": "https://www.theguardian.com/culture/comedy",
+            "apiUrl": "https://content.guardianapis.com/culture/comedy",
+            "references": [],
+            "internalName": "Comedy (culture)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-660fbe9e8f085621a68051ba",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/04/05-33781-gdn.CE.20240409.ds.Kiri_Pritchard_McLean.mp3",
+                "typeData": {
+                  "source": "The Guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/04/05-33781-gdn.CE.20240409.ds.Kiri_Pritchard_McLean.mp3",
+                  "sizeInBytes": "61276263",
+                  "durationMinutes": "39",
+                  "durationSeconds": "56",
+                  "embedType": "audio",
+                  "explicit": "true",
+                  "clean": "false"
+                }
+              }
+            ]
+          },
+          {
+            "id": "7ea748d4d3b681e71b4ba673d390f2268aa587ff",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/7ea748d4d3b681e71b4ba673d390f2268aa587ff/0_0_3000_1800/master/3000.jpg",
+                "typeData": {
+                  "altText": "Kiri Pritchard-McLean and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "3000",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/7ea748d4d3b681e71b4ba673d390f2268aa587ff/0_0_3000_1800/master/3000.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "7ea748d4d3b681e71b4ba673d390f2268aa587ff",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/7ea748d4d3b681e71b4ba673d390f2268aa587ff"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/7ea748d4d3b681e71b4ba673d390f2268aa587ff/0_0_3000_1800/3000.jpg",
+                "typeData": {
+                  "altText": "Kiri Pritchard-McLean and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "3000",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/7ea748d4d3b681e71b4ba673d390f2268aa587ff/0_0_3000_1800/3000.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "7ea748d4d3b681e71b4ba673d390f2268aa587ff",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/7ea748d4d3b681e71b4ba673d390f2268aa587ff"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/7ea748d4d3b681e71b4ba673d390f2268aa587ff/0_0_3000_1800/500.jpg",
+                "typeData": {
+                  "altText": "Kiri Pritchard-McLean and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/7ea748d4d3b681e71b4ba673d390f2268aa587ff/0_0_3000_1800/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "7ea748d4d3b681e71b4ba673d390f2268aa587ff",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/7ea748d4d3b681e71b4ba673d390f2268aa587ff"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle"
+      },
+      {
+        "id": "lifeandstyle/audio/2024/apr/02/s6-ep-8-tom-kerridge-chef",
+        "type": "audio",
+        "sectionId": "lifeandstyle",
+        "sectionName": "Life and style",
+        "webPublicationDate": "2024-04-02T04:00:29Z",
+        "webTitle": "S6, Ep 8: Tom Kerridge, chef",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/audio/2024/apr/02/s6-ep-8-tom-kerridge-chef",
+        "apiUrl": "https://content.guardianapis.com/lifeandstyle/audio/2024/apr/02/s6-ep-8-tom-kerridge-chef",
+        "fields": {
+          "standfirst": "<p>Comfort Eating’s culinary standards might have been permanently raised after two-Michelin-star chef Tom Kerridge’s visit. But he’s not exactly one to show off. Growing up in Gloucester, Tom always wanted to recreate the homely meals he’d find at his local pub or at his mum’s on Sundays.</p><p>With a brief detour on to the acting stage, Tom started his career working at some of the country’s top restaurants. In the rock’n’roll era of fine dining, suddenly it was cool to be working in a restaurant late at night.</p><p>But as Tom and Grace discuss, a world of late hours and excess triggered multiple health problems for him. Going sober and solo, Tom started running his own businesses and success quickly followed. So what exactly does a top chef snack on when they’re not winning awards? You might be surprised …</p>",
+          "trailText": "Grace welcomes two-Michelin-star chef Tom Kerridge to her living room this week to talk fine-dining, going sober, and of course … what snacks keep him going",
+          "internalComposerCode": "66054a488f087a4188961062"
+        },
+        "tags": [
+          {
+            "id": "food/tom-kerridge",
+            "type": "keyword",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Tom Kerridge",
+            "webUrl": "https://www.theguardian.com/food/tom-kerridge",
+            "apiUrl": "https://content.guardianapis.com/food/tom-kerridge",
+            "references": [],
+            "internalName": "Tom Kerridge (chef)"
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://content.guardianapis.com/food/food",
+            "references": [],
+            "internalName": "Food"
+          },
+          {
+            "id": "lifeandstyle/lifeandstyle",
+            "type": "keyword",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life and style",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/lifeandstyle",
+            "apiUrl": "https://content.guardianapis.com/lifeandstyle/lifeandstyle",
+            "references": [],
+            "internalName": "Life and style"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-66054a488f087a4188961062",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/03/28-49047-gdn.ce.20240402.ds.Tom_Kerridge.mp3",
+                "typeData": {
+                  "secureFile": "https://audio.guim.co.uk/2024/03/28-49047-gdn.ce.20240402.ds.Tom_Kerridge.mp3",
+                  "sizeInBytes": "63054063",
+                  "durationMinutes": "41",
+                  "durationSeconds": "10",
+                  "embedType": "audio"
+                }
+              }
+            ]
+          },
+          {
+            "id": "e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9/0_0_2999_1800/master/2999.jpg",
+                "typeData": {
+                  "altText": "Tom Kerridge and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9/0_0_2999_1800/master/2999.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9/0_0_2999_1800/2999.jpg",
+                "typeData": {
+                  "altText": "Tom Kerridge and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9/0_0_2999_1800/2999.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9/0_0_2999_1800/500.jpg",
+                "typeData": {
+                  "altText": "Tom Kerridge and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9/0_0_2999_1800/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/e50f5106e2ad5160d6510e1d11a5dc5f7a7725a9"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle"
+      },
+      {
+        "id": "lifeandstyle/audio/2024/mar/26/s6-ep-7-cat-burns-singer",
+        "type": "audio",
+        "sectionId": "lifeandstyle",
+        "sectionName": "Life and style",
+        "webPublicationDate": "2024-03-26T05:00:22Z",
+        "webTitle": "S6 Ep 7: Cat Burns, singer",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/audio/2024/mar/26/s6-ep-7-cat-burns-singer",
+        "apiUrl": "https://content.guardianapis.com/lifeandstyle/audio/2024/mar/26/s6-ep-7-cat-burns-singer",
+        "fields": {
+          "standfirst": "<p>Platinum-selling singer songwriter Cat Burns cosies up with Grace for a warm plate of nosh and some deep chats. The biggest-selling British female artist of 2022, who won three Brit award nominations after her single Go went viral on TikTok, reveals how she went from shy schoolgirl to stadium gigs in just a few years. While Covid put an end to busking on the South Bank, it opened up another portal on social channels that sent Cat’s star on its rapid ascent.</p><p>Recently diagnosed as autistic, Cat explains how her relationship with food thrives on predictability and consistency. Yet with a small recipe suggestion from her girlfriend, she had a lightbulb moment – opening up new possibilities. Cat says she doesn’t do small talk, which is more than OK; her big talk is just beautiful.</p>",
+          "trailText": "Platinum-selling singer songwriter Cat Burns cosies up with Grace for a warm plate of nosh and some deep chats",
+          "internalComposerCode": "65fd51098f0872bcdbfc1d5d"
+        },
+        "tags": [
+          {
+            "id": "music/music",
+            "type": "keyword",
+            "sectionId": "music",
+            "sectionName": "Music",
+            "webTitle": "Music",
+            "webUrl": "https://www.theguardian.com/music/music",
+            "apiUrl": "https://content.guardianapis.com/music/music",
+            "references": [],
+            "internalName": "Music"
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://content.guardianapis.com/food/food",
+            "references": [],
+            "internalName": "Food"
+          },
+          {
+            "id": "culture/culture",
+            "type": "keyword",
+            "sectionId": "culture",
+            "sectionName": "Culture",
+            "webTitle": "Culture",
+            "webUrl": "https://www.theguardian.com/culture/culture",
+            "apiUrl": "https://content.guardianapis.com/culture/culture",
+            "references": [],
+            "internalName": "Culture"
+          },
+          {
+            "id": "society/autism",
+            "type": "keyword",
+            "sectionId": "society",
+            "sectionName": "Society",
+            "webTitle": "Autism",
+            "webUrl": "https://www.theguardian.com/society/autism",
+            "apiUrl": "https://content.guardianapis.com/society/autism",
+            "references": [],
+            "internalName": "Autism (Society)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-65fd51098f0872bcdbfc1d5d",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/03/25-32938-gdn.ce.20240326.ds.Cat_Burns.mp3",
+                "typeData": {
+                  "source": "The Guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/03/25-32938-gdn.ce.20240326.ds.Cat_Burns.mp3",
+                  "sizeInBytes": "63423971",
+                  "durationMinutes": "41",
+                  "durationSeconds": "26",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "384a2ee74f6c35dc7197ec9191bcec093f5f2322",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/384a2ee74f6c35dc7197ec9191bcec093f5f2322/0_0_2999_1800/master/2999.jpg",
+                "typeData": {
+                  "altText": "Cat Burns and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/384a2ee74f6c35dc7197ec9191bcec093f5f2322/0_0_2999_1800/master/2999.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "384a2ee74f6c35dc7197ec9191bcec093f5f2322",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/384a2ee74f6c35dc7197ec9191bcec093f5f2322"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/384a2ee74f6c35dc7197ec9191bcec093f5f2322/0_0_2999_1800/2999.jpg",
+                "typeData": {
+                  "altText": "Cat Burns and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/384a2ee74f6c35dc7197ec9191bcec093f5f2322/0_0_2999_1800/2999.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "384a2ee74f6c35dc7197ec9191bcec093f5f2322",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/384a2ee74f6c35dc7197ec9191bcec093f5f2322"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/384a2ee74f6c35dc7197ec9191bcec093f5f2322/0_0_2999_1800/500.jpg",
+                "typeData": {
+                  "altText": "Cat Burns and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/384a2ee74f6c35dc7197ec9191bcec093f5f2322/0_0_2999_1800/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "384a2ee74f6c35dc7197ec9191bcec093f5f2322",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/384a2ee74f6c35dc7197ec9191bcec093f5f2322"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle"
+      },
+      {
+        "id": "lifeandstyle/audio/2024/mar/19/s6-ep-6-daniel-foxx-playwright",
+        "type": "audio",
+        "sectionId": "lifeandstyle",
+        "sectionName": "Life and style",
+        "webPublicationDate": "2024-03-19T05:00:23Z",
+        "webTitle": "S6 Ep 6: Daniel Foxx, comedian",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/audio/2024/mar/19/s6-ep-6-daniel-foxx-playwright",
+        "apiUrl": "https://content.guardianapis.com/lifeandstyle/audio/2024/mar/19/s6-ep-6-daniel-foxx-playwright",
+        "fields": {
+          "standfirst": "<p>Sliding into Grace’s sitting room this week is rising star and multitalented comedian, playwright and musical theatre creator, Daniel Foxx. Bringing his concoction of gunk meant only for solo consumption in the small hours, there’s nowhere left to hide. Buckle up and join Grace and Daniel as they go on a tour of the ins and outs of life in the fast lane – or is that the M6 at 1am?</p><p>Daniel shares his different incarnations – from coming out age 11 to donning a string of pearls post-lockdown. His observational obsessions have helped to feed his viral hit The Supervillain’s Gay Assistant and Grace and Daniel unpick its threads with scurrilous delight. Oh, and there’s a modern-day love story involving Tinder and trains. Scoop it all up with love and a crunchy lentil curl</p>",
+          "trailText": "Buckle up and join Grace and Daniel as they go on a tour of the ins and outs of life in the fast lane – or is that the M6 at 1am?",
+          "internalComposerCode": "65f183a08f0836980f1afdec"
+        },
+        "tags": [
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://content.guardianapis.com/food/food",
+            "references": [],
+            "internalName": "Food"
+          },
+          {
+            "id": "stage/theatre",
+            "type": "keyword",
+            "sectionId": "stage",
+            "sectionName": "Stage",
+            "webTitle": "Theatre",
+            "webUrl": "https://www.theguardian.com/stage/theatre",
+            "apiUrl": "https://content.guardianapis.com/stage/theatre",
+            "references": [],
+            "internalName": "Theatre"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-65f183a08f0836980f1afdec",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/03/13-42841-gdn.ce.20240319.ds.Foxx_Daniel.mp3",
+                "typeData": {
+                  "source": "The Guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/03/13-42841-gdn.ce.20240319.ds.Foxx_Daniel.mp3",
+                  "sizeInBytes": "69577821",
+                  "durationMinutes": "45",
+                  "durationSeconds": "42",
+                  "embedType": "audio",
+                  "explicit": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "62da4337f2f88cababe9cfd7e8f7467c4c17fd98",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/62da4337f2f88cababe9cfd7e8f7467c4c17fd98/0_0_3000_1800/master/3000.jpg",
+                "typeData": {
+                  "altText": "Daniel Fox and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "3000",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/62da4337f2f88cababe9cfd7e8f7467c4c17fd98/0_0_3000_1800/master/3000.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "62da4337f2f88cababe9cfd7e8f7467c4c17fd98",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/62da4337f2f88cababe9cfd7e8f7467c4c17fd98"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/62da4337f2f88cababe9cfd7e8f7467c4c17fd98/0_0_3000_1800/3000.jpg",
+                "typeData": {
+                  "altText": "Daniel Fox and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "3000",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/62da4337f2f88cababe9cfd7e8f7467c4c17fd98/0_0_3000_1800/3000.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "62da4337f2f88cababe9cfd7e8f7467c4c17fd98",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/62da4337f2f88cababe9cfd7e8f7467c4c17fd98"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/62da4337f2f88cababe9cfd7e8f7467c4c17fd98/0_0_3000_1800/500.jpg",
+                "typeData": {
+                  "altText": "Daniel Fox and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/62da4337f2f88cababe9cfd7e8f7467c4c17fd98/0_0_3000_1800/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "62da4337f2f88cababe9cfd7e8f7467c4c17fd98",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/62da4337f2f88cababe9cfd7e8f7467c4c17fd98"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle"
+      },
+      {
+        "id": "lifeandstyle/audio/2024/mar/12/s6-ep-5-amol-rajan-broadcaster",
+        "type": "audio",
+        "sectionId": "lifeandstyle",
+        "sectionName": "Life and style",
+        "webPublicationDate": "2024-03-12T05:00:58Z",
+        "webTitle": "S6 Ep 5: Amol Rajan, broadcaster",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/audio/2024/mar/12/s6-ep-5-amol-rajan-broadcaster",
+        "apiUrl": "https://content.guardianapis.com/lifeandstyle/audio/2024/mar/12/s6-ep-5-amol-rajan-broadcaster",
+        "fields": {
+          "standfirst": "<p>It’s tough presenting BBC radio’s top morning news programme, hosting the nation’s brainiest quiz show and being a devoted dad to four young children. But someone’s got to do it. And that person is none other than the broadcaster Amol Rajan. Having risen through the ranks of the Independent newspaper to be its youngest editor at the age of 29 and now only the third ever presenter of University Challenge, there’s got to be something fuelling this dynamo.</p><p>Finding a little window in his busy schedule, Amol parks his responsibilities at the door and shares the secrets of his success and culinary tricks with long-time friend and former colleague, Grace. From his mum’s incredible home cooking to his special porridge recipe for when the kids aren’t looking, Amol tells all. There’s some raving, insomnia and umami twang thrown in too – you might have seen them at Reading?</p>",
+          "trailText": "Finding a little window in his busy schedule, Amol parks his responsibilities at the door and shares the secrets of his success and culinary tricks with long-time friend and former colleague, Grace",
+          "internalComposerCode": "65e877458f08d97cd1fc2688"
+        },
+        "tags": [
+          {
+            "id": "media/amol-rajan",
+            "type": "keyword",
+            "sectionId": "media",
+            "sectionName": "Media",
+            "webTitle": "Amol Rajan",
+            "webUrl": "https://www.theguardian.com/media/amol-rajan",
+            "apiUrl": "https://content.guardianapis.com/media/amol-rajan",
+            "references": [],
+            "description": "The latest news and comment on Amol Rajan",
+            "internalName": "Amol Rajan (Media)"
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://content.guardianapis.com/food/food",
+            "references": [],
+            "internalName": "Food"
+          },
+          {
+            "id": "tv-and-radio/university-challenge",
+            "type": "keyword",
+            "sectionId": "tv-and-radio",
+            "sectionName": "Television & radio",
+            "webTitle": "University Challenge",
+            "webUrl": "https://www.theguardian.com/tv-and-radio/university-challenge",
+            "apiUrl": "https://content.guardianapis.com/tv-and-radio/university-challenge",
+            "references": [],
+            "internalName": "University Challenge"
+          },
+          {
+            "id": "media/bbc",
+            "type": "keyword",
+            "sectionId": "media",
+            "sectionName": "Media",
+            "webTitle": "BBC",
+            "webUrl": "https://www.theguardian.com/media/bbc",
+            "apiUrl": "https://content.guardianapis.com/media/bbc",
+            "references": [],
+            "internalName": "BBC"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-65e877458f08d97cd1fc2688",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/03/07-50092-gdn.ce.20240312.ds.Amol_Rajan.mp3",
+                "typeData": {
+                  "source": "The Guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/03/07-50092-gdn.ce.20240312.ds.Amol_Rajan.mp3",
+                  "sizeInBytes": "70309219",
+                  "durationMinutes": "46",
+                  "durationSeconds": "12",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "6a08cb6e8f4a2c2499a846922b1db752b1f5a27f",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/6a08cb6e8f4a2c2499a846922b1db752b1f5a27f/0_0_2999_1800/master/2999.jpg",
+                "typeData": {
+                  "altText": "Amol Rajan and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/6a08cb6e8f4a2c2499a846922b1db752b1f5a27f/0_0_2999_1800/master/2999.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "6a08cb6e8f4a2c2499a846922b1db752b1f5a27f",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/6a08cb6e8f4a2c2499a846922b1db752b1f5a27f"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/6a08cb6e8f4a2c2499a846922b1db752b1f5a27f/0_0_2999_1800/2999.jpg",
+                "typeData": {
+                  "altText": "Amol Rajan and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/6a08cb6e8f4a2c2499a846922b1db752b1f5a27f/0_0_2999_1800/2999.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "6a08cb6e8f4a2c2499a846922b1db752b1f5a27f",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/6a08cb6e8f4a2c2499a846922b1db752b1f5a27f"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/6a08cb6e8f4a2c2499a846922b1db752b1f5a27f/0_0_2999_1800/500.jpg",
+                "typeData": {
+                  "altText": "Amol Rajan and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/6a08cb6e8f4a2c2499a846922b1db752b1f5a27f/0_0_2999_1800/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "6a08cb6e8f4a2c2499a846922b1db752b1f5a27f",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/6a08cb6e8f4a2c2499a846922b1db752b1f5a27f"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle"
+      },
+      {
+        "id": "lifeandstyle/audio/2024/mar/05/s6-ep-4-katie-price-model-turned-reality-tv-star",
+        "type": "audio",
+        "sectionId": "lifeandstyle",
+        "sectionName": "Life and style",
+        "webPublicationDate": "2024-03-05T05:01:02Z",
+        "webTitle": "S6 Ep 4: Katie Price, model turned reality TV star",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/audio/2024/mar/05/s6-ep-4-katie-price-model-turned-reality-tv-star",
+        "apiUrl": "https://content.guardianapis.com/lifeandstyle/audio/2024/mar/05/s6-ep-4-katie-price-model-turned-reality-tv-star",
+        "fields": {
+          "standfirst": "<p>Dropping by this week for a spot of comfort eating is the legendary glamour model turned reality TV star, Katie Price. One of the most photographed and filmed women of our times, splashed across page 3 and lads mags as Jordan 30 years ago, then in six of her own TV series, multiple documentaries and reality shows, everyone thinks they know her. But talking to Grace over a squishy, soft and ‘bald’ dish, Katie reveals a more nuanced picture – opening up about childhood, horses, early photoshoots, love, abuse, men, the media, breakdown and being a proud mum of five. ‘Never underestimate the Pricey’ – it’s a motto to live by and Grace embraces it all – the ups, the downs and snacks in between</p>",
+          "trailText": "Talking to Grace over a squishy, soft and ‘bald’ dish, Katie reveals a more nuanced picture - opening up about childhood, horses, early photoshoots, love, abuse, men, the media, breakdown and being a proud mum of five",
+          "internalComposerCode": "65e062fd8f08b6f9684f4769"
+        },
+        "tags": [
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://content.guardianapis.com/food/food",
+            "references": [],
+            "internalName": "Food"
+          },
+          {
+            "id": "tv-and-radio/reality-tv",
+            "type": "keyword",
+            "sectionId": "tv-and-radio",
+            "sectionName": "Television & radio",
+            "webTitle": "Reality TV",
+            "webUrl": "https://www.theguardian.com/tv-and-radio/reality-tv",
+            "apiUrl": "https://content.guardianapis.com/tv-and-radio/reality-tv",
+            "references": [],
+            "internalName": "Reality TV (TV genre)"
+          },
+          {
+            "id": "fashion/models",
+            "type": "keyword",
+            "sectionId": "fashion",
+            "sectionName": "Fashion",
+            "webTitle": "Models",
+            "webUrl": "https://www.theguardian.com/fashion/models",
+            "apiUrl": "https://content.guardianapis.com/fashion/models",
+            "references": [],
+            "internalName": "Models (Fashion)"
+          },
+          {
+            "id": "media/katieprice",
+            "type": "keyword",
+            "sectionId": "media",
+            "sectionName": "Media",
+            "webTitle": "Katie Price",
+            "webUrl": "https://www.theguardian.com/media/katieprice",
+            "apiUrl": "https://content.guardianapis.com/media/katieprice",
+            "references": [],
+            "internalName": "Katie Price (Media)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-65e062fd8f08b6f9684f4769",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/03/04-63634-gdn.ce.20240305.ds.Katie_Price.mp3",
+                "typeData": {
+                  "source": "The Guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/03/04-63634-gdn.ce.20240305.ds.Katie_Price.mp3",
+                  "sizeInBytes": "66478528",
+                  "durationMinutes": "43",
+                  "durationSeconds": "33",
+                  "embedType": "audio",
+                  "explicit": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "486ccd6f411894d2b7cbee1b483103f46ec97b47",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/486ccd6f411894d2b7cbee1b483103f46ec97b47/0_0_2999_1800/master/2999.jpg",
+                "typeData": {
+                  "altText": "Katie Price and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/486ccd6f411894d2b7cbee1b483103f46ec97b47/0_0_2999_1800/master/2999.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "486ccd6f411894d2b7cbee1b483103f46ec97b47",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/486ccd6f411894d2b7cbee1b483103f46ec97b47"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/486ccd6f411894d2b7cbee1b483103f46ec97b47/0_0_2999_1800/2999.jpg",
+                "typeData": {
+                  "altText": "Katie Price and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/486ccd6f411894d2b7cbee1b483103f46ec97b47/0_0_2999_1800/2999.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "486ccd6f411894d2b7cbee1b483103f46ec97b47",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/486ccd6f411894d2b7cbee1b483103f46ec97b47"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/486ccd6f411894d2b7cbee1b483103f46ec97b47/0_0_2999_1800/500.jpg",
+                "typeData": {
+                  "altText": "Katie Price and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/486ccd6f411894d2b7cbee1b483103f46ec97b47/0_0_2999_1800/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "486ccd6f411894d2b7cbee1b483103f46ec97b47",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/486ccd6f411894d2b7cbee1b483103f46ec97b47"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle"
+      },
+      {
+        "id": "lifeandstyle/audio/2024/mar/01/from-the-archive-season-2-dave-myers-hairy-biker",
+        "type": "audio",
+        "sectionId": "lifeandstyle",
+        "sectionName": "Life and style",
+        "webPublicationDate": "2024-03-01T10:18:12Z",
+        "webTitle": "From the archive (season 2): Dave Myers, hairy biker",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/audio/2024/mar/01/from-the-archive-season-2-dave-myers-hairy-biker",
+        "apiUrl": "https://content.guardianapis.com/lifeandstyle/audio/2024/mar/01/from-the-archive-season-2-dave-myers-hairy-biker",
+        "fields": {
+          "standfirst": "<p>This week, the world learned of the sad passing of a true British icon, TV cook and hairy biker, Dave Myers. To celebrate his life, we wanted to bring you this episode from January 2022 where Dave tells Grace about – ironically – losing all his hair aged eight, his years as a makeup artist, working in the steelyards of Barrow-in-Furness, and the comfort foods that have seen him through it all</p>",
+          "trailText": "From January 2022: Dave tells Grace about – ironically – losing all his hair aged eight, his years as a makeup artist and working in the steelyards of Barrow-in-Furness",
+          "internalComposerCode": "65e19f7b8f081efc37d4aea7"
+        },
+        "tags": [
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://content.guardianapis.com/food/food",
+            "references": [],
+            "internalName": "Food"
+          },
+          {
+            "id": "culture/television",
+            "type": "keyword",
+            "sectionId": "tv-and-radio",
+            "sectionName": "Television & radio",
+            "webTitle": "Television",
+            "webUrl": "https://www.theguardian.com/culture/television",
+            "apiUrl": "https://content.guardianapis.com/culture/television",
+            "references": [],
+            "internalName": "Television (Culture)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-65e19f7b8f081efc37d4aea7",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/03/01-34708-gdn.CE.20240301.ds.Dave_Myers_reuploaded.mp3",
+                "typeData": {
+                  "source": "The Guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/03/01-34708-gdn.CE.20240301.ds.Dave_Myers_reuploaded.mp3",
+                  "sizeInBytes": "59108704",
+                  "durationMinutes": "38",
+                  "durationSeconds": "26",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "65c7d433856aaea27f602186d527c76189d8f8c8",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/65c7d433856aaea27f602186d527c76189d8f8c8/0_0_2999_1800/master/2999.jpg",
+                "typeData": {
+                  "altText": "Podcast Grace Dent Guest Specific Organic Social S2 E11 3000x1800",
+                  "credit": "Photograph: Leah Green/The Guardian",
+                  "photographer": "Leah Green",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/65c7d433856aaea27f602186d527c76189d8f8c8/0_0_2999_1800/master/2999.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "65c7d433856aaea27f602186d527c76189d8f8c8",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/65c7d433856aaea27f602186d527c76189d8f8c8"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/65c7d433856aaea27f602186d527c76189d8f8c8/0_0_2999_1800/2999.jpg",
+                "typeData": {
+                  "altText": "Podcast Grace Dent Guest Specific Organic Social S2 E11 3000x1800",
+                  "credit": "Photograph: Leah Green/The Guardian",
+                  "photographer": "Leah Green",
+                  "source": "The Guardian",
+                  "width": "2999",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/65c7d433856aaea27f602186d527c76189d8f8c8/0_0_2999_1800/2999.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "65c7d433856aaea27f602186d527c76189d8f8c8",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/65c7d433856aaea27f602186d527c76189d8f8c8"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/65c7d433856aaea27f602186d527c76189d8f8c8/0_0_2999_1800/500.jpg",
+                "typeData": {
+                  "altText": "Podcast Grace Dent Guest Specific Organic Social S2 E11 3000x1800",
+                  "credit": "Photograph: Leah Green/The Guardian",
+                  "photographer": "Leah Green",
+                  "source": "The Guardian",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/65c7d433856aaea27f602186d527c76189d8f8c8/0_0_2999_1800/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "65c7d433856aaea27f602186d527c76189d8f8c8",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/65c7d433856aaea27f602186d527c76189d8f8c8"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle"
+      },
+      {
+        "id": "lifeandstyle/audio/2024/feb/27/s6-e3-kathy-burke-actor-director-and-writer",
+        "type": "audio",
+        "sectionId": "lifeandstyle",
+        "sectionName": "Life and style",
+        "webPublicationDate": "2024-02-27T05:00:13Z",
+        "webTitle": "S6 E3: Kathy Burke, actor, director and writer",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/audio/2024/feb/27/s6-e3-kathy-burke-actor-director-and-writer",
+        "apiUrl": "https://content.guardianapis.com/lifeandstyle/audio/2024/feb/27/s6-e3-kathy-burke-actor-director-and-writer",
+        "fields": {
+          "standfirst": "<p>One of the UK’s most loved and versatile actors, Kathy Burke, lands in Grace’s sitting room this week. Transitioning from punk teenager, to award-winning actor and then taking on comedy, Kathy has loved almost all of it. She talks to Grace about her career highlights and when her personal life sometimes got in the way, recounting the food that got her through. Whether it’s eating fish and chips on a film set with Ray Winstone, a love-hate relationship with bananas and beans, or coming to adore biscuits in her 50s, Kathy and Grace reminisce about it all. And hey, sometimes all you need is a bit of burnt toast</p>",
+          "trailText": "One of the UK’s most loved and versatile actors and writers, Kathy Burke, lands in Grace’s sitting room this week",
+          "internalComposerCode": "65d76b918f0877292bb35a78"
+        },
+        "tags": [
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://content.guardianapis.com/food/food",
+            "references": [],
+            "internalName": "Food"
+          },
+          {
+            "id": "lifeandstyle/lifeandstyle",
+            "type": "keyword",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life and style",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/lifeandstyle",
+            "apiUrl": "https://content.guardianapis.com/lifeandstyle/lifeandstyle",
+            "references": [],
+            "internalName": "Life and style"
+          },
+          {
+            "id": "culture/kathy-burke",
+            "type": "keyword",
+            "sectionId": "culture",
+            "sectionName": "Culture",
+            "webTitle": "Kathy Burke",
+            "webUrl": "https://www.theguardian.com/culture/kathy-burke",
+            "apiUrl": "https://content.guardianapis.com/culture/kathy-burke",
+            "references": [],
+            "internalName": "Kathy Burke"
+          },
+          {
+            "id": "culture/comedy",
+            "type": "keyword",
+            "sectionId": "culture",
+            "sectionName": "Culture",
+            "webTitle": "Comedy",
+            "webUrl": "https://www.theguardian.com/culture/comedy",
+            "apiUrl": "https://content.guardianapis.com/culture/comedy",
+            "references": [],
+            "internalName": "Comedy (culture)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-65d76b918f0877292bb35a78",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/02/23-40330-gdn.CE.20240227.ds.Kathy_Burke.mp3",
+                "typeData": {
+                  "source": "The Guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/02/23-40330-gdn.CE.20240227.ds.Kathy_Burke.mp3",
+                  "sizeInBytes": "62821312",
+                  "durationMinutes": "41",
+                  "durationSeconds": "1",
+                  "embedType": "audio",
+                  "explicit": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "048cb5228a50eb0f916272ecfca2278c1a2a1f6b",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/048cb5228a50eb0f916272ecfca2278c1a2a1f6b/0_0_3000_1800/master/3000.jpg",
+                "typeData": {
+                  "altText": "KathyBurke and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "3000",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/048cb5228a50eb0f916272ecfca2278c1a2a1f6b/0_0_3000_1800/master/3000.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "048cb5228a50eb0f916272ecfca2278c1a2a1f6b",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/048cb5228a50eb0f916272ecfca2278c1a2a1f6b"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/048cb5228a50eb0f916272ecfca2278c1a2a1f6b/0_0_3000_1800/3000.jpg",
+                "typeData": {
+                  "altText": "KathyBurke and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "3000",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/048cb5228a50eb0f916272ecfca2278c1a2a1f6b/0_0_3000_1800/3000.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "048cb5228a50eb0f916272ecfca2278c1a2a1f6b",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/048cb5228a50eb0f916272ecfca2278c1a2a1f6b"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/048cb5228a50eb0f916272ecfca2278c1a2a1f6b/0_0_3000_1800/500.jpg",
+                "typeData": {
+                  "altText": "KathyBurke and Grace Dent",
+                  "credit": "Photograph: Sophie Harrow/The Guardian",
+                  "photographer": "Sophie Harrow",
+                  "source": "The Guardian",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/048cb5228a50eb0f916272ecfca2278c1a2a1f6b/0_0_3000_1800/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "048cb5228a50eb0f916272ecfca2278c1a2a1f6b",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/048cb5228a50eb0f916272ecfca2278c1a2a1f6b"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle"
+      },
+      {
+        "id": "lifeandstyle/audio/2024/feb/20/s6-e2-michelle-de-swarte-comedian",
+        "type": "audio",
+        "sectionId": "lifeandstyle",
+        "sectionName": "Life and style",
+        "webPublicationDate": "2024-02-20T05:00:37Z",
+        "webTitle": "S6 E2: Michelle de Swarte, comedian",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/audio/2024/feb/20/s6-e2-michelle-de-swarte-comedian",
+        "apiUrl": "https://content.guardianapis.com/lifeandstyle/audio/2024/feb/20/s6-e2-michelle-de-swarte-comedian",
+        "fields": {
+          "standfirst": "<p>Model-turned-standup Michelle De Swarte knows how to make an entrance. And arriving at Grace’s with her eat-it-or-climb-it comfort snack of choice, she doesn’t disappoint. For the woman who left school at 14, signed as a model at 19, fell on the Gucci catwalk a month later, modelled for years in New York afterwards and then changed tack to become a comedian, life is what you make it.</p><p>Straight-talking, no-nonsense, Michelle and Grace get down to business and discover their shared dependence on a well-known sandwich chain. There’s glitz, there’s glamour, and quite a lot of rude bits. Sorry, not sorry</p>",
+          "trailText": "Straight-talking, no-nonsense, Michelle and Grace get down to business and discover their shared dependence on a well-known sandwich chain. There’s glitz, there’s glamour, and quite a lot of rude bits. Sorry, not sorry",
+          "internalComposerCode": "65cf52068f08fee2fe08c0ff"
+        },
+        "tags": [
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://content.guardianapis.com/food/food",
+            "references": [],
+            "internalName": "Food"
+          },
+          {
+            "id": "fashion/models",
+            "type": "keyword",
+            "sectionId": "fashion",
+            "sectionName": "Fashion",
+            "webTitle": "Models",
+            "webUrl": "https://www.theguardian.com/fashion/models",
+            "apiUrl": "https://content.guardianapis.com/fashion/models",
+            "references": [],
+            "internalName": "Models (Fashion)"
+          },
+          {
+            "id": "stage/comedy",
+            "type": "keyword",
+            "sectionId": "stage",
+            "sectionName": "Stage",
+            "webTitle": "Comedy",
+            "webUrl": "https://www.theguardian.com/stage/comedy",
+            "apiUrl": "https://content.guardianapis.com/stage/comedy",
+            "references": [],
+            "internalName": "Comedy live (Stage)"
+          },
+          {
+            "id": "lifeandstyle/lifeandstyle",
+            "type": "keyword",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life and style",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/lifeandstyle",
+            "apiUrl": "https://content.guardianapis.com/lifeandstyle/lifeandstyle",
+            "references": [],
+            "internalName": "Life and style"
+          },
+          {
+            "id": "culture/comedy",
+            "type": "keyword",
+            "sectionId": "culture",
+            "sectionName": "Culture",
+            "webTitle": "Comedy",
+            "webUrl": "https://www.theguardian.com/culture/comedy",
+            "apiUrl": "https://content.guardianapis.com/culture/comedy",
+            "references": [],
+            "internalName": "Comedy (culture)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-65cf52068f08fee2fe08c0ff",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/02/19-46666-gdn.ce.20240220.ds.S6_Ep2_Michelle_de_Swarte.mp3",
+                "typeData": {
+                  "source": "The Guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/02/19-46666-gdn.ce.20240220.ds.S6_Ep2_Michelle_de_Swarte.mp3",
+                  "sizeInBytes": "62241981",
+                  "durationMinutes": "40",
+                  "durationSeconds": "36",
+                  "embedType": "audio",
+                  "explicit": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "550209fb82a951add875623e1be008b329e203dd",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/550209fb82a951add875623e1be008b329e203dd/0_0_3000_1800/master/3000.jpg",
+                "typeData": {
+                  "altText": "MichelledeSwarte 3000x1800",
+                  "credit": "Photograph: Ruth Abrahams/The Guardian",
+                  "photographer": "Ruth Abrahams",
+                  "source": "The Guardian",
+                  "width": "3000",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/550209fb82a951add875623e1be008b329e203dd/0_0_3000_1800/master/3000.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "550209fb82a951add875623e1be008b329e203dd",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/550209fb82a951add875623e1be008b329e203dd"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/550209fb82a951add875623e1be008b329e203dd/0_0_3000_1800/3000.jpg",
+                "typeData": {
+                  "altText": "MichelledeSwarte 3000x1800",
+                  "credit": "Photograph: Ruth Abrahams/The Guardian",
+                  "photographer": "Ruth Abrahams",
+                  "source": "The Guardian",
+                  "width": "3000",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/550209fb82a951add875623e1be008b329e203dd/0_0_3000_1800/3000.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "550209fb82a951add875623e1be008b329e203dd",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/550209fb82a951add875623e1be008b329e203dd"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/550209fb82a951add875623e1be008b329e203dd/0_0_3000_1800/500.jpg",
+                "typeData": {
+                  "altText": "MichelledeSwarte 3000x1800",
+                  "credit": "Photograph: Ruth Abrahams/The Guardian",
+                  "photographer": "Ruth Abrahams",
+                  "source": "The Guardian",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/550209fb82a951add875623e1be008b329e203dd/0_0_3000_1800/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "550209fb82a951add875623e1be008b329e203dd",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/550209fb82a951add875623e1be008b329e203dd"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle"
+      }
+    ]
+  }
+}

--- a/test/resources/itunes-capi-full-story-response.json
+++ b/test/resources/itunes-capi-full-story-response.json
@@ -1,0 +1,2075 @@
+{
+  "response": {
+    "status": "ok",
+    "userTier": "internal",
+    "total": 1233,
+    "startIndex": 1,
+    "pageSize": 4,
+    "currentPage": 1,
+    "pages": 309,
+    "orderBy": "newest",
+    "tag": {
+      "id": "australia-news/series/full-story",
+      "type": "series",
+      "sectionId": "australia-news",
+      "sectionName": "Australia news",
+      "webTitle": "Full Story",
+      "webUrl": "https://www.theguardian.com/australia-news/series/full-story",
+      "apiUrl": "https://content.guardianapis.com/australia-news/series/full-story",
+      "description": "<p>You’ve seen the headlines, now hear the Full Story. Every weekday, join Guardian journalists for a deeper understanding of the news in Australia and beyond. You can support The Guardian at&nbsp;<a href=\"http://theguardian.com/fullstorysupport\">theguardian.com/fullstorysupport</a></p>",
+      "podcast": {
+        "linkUrl": "https://www.theguardian.com/au",
+        "copyright": "© 2024 Guardian News & Media Limited or its affiliated companies. All rights reserved. ",
+        "author": "Guardian Australia",
+        "subscriptionUrl": "https://podcasts.apple.com/au/podcast/full-story/id1482061243",
+        "explicit": false,
+        "image": "https://uploads.guim.co.uk/2024/03/31/TheGuardian_FullStory2022_3000x3000.jpg",
+        "categories": [
+          {
+            "main": "News"
+          }
+        ],
+        "podcastType": "episodic",
+        "googlePodcastsUrl": "https://podcasts.google.com/?feed=aHR0cHM6Ly93d3cudGhlZ3VhcmRpYW4uY29tL2F1c3RyYWxpYS1uZXdzL3Nlcmllcy9mdWxsLXN0b3J5L3BvZGNhc3QueG1s&hl=en-AU",
+        "spotifyUrl": "https://open.spotify.com/show/7GJod4EyoLywB1AW6zrSHh"
+      },
+      "internalName": "Full Story (podcast)"
+    },
+    "results": [
+      {
+        "id": "australia-news/audio/2024/may/07/india-election-whats-at-stake-for-democracy-under-modi-full-story-podcast",
+        "type": "audio",
+        "sectionId": "australia-news",
+        "sectionName": "Australia news",
+        "webPublicationDate": "2024-05-07T15:00:19Z",
+        "webTitle": "India election: what’s at stake for democracy under Modi? - podcast",
+        "webUrl": "https://www.theguardian.com/australia-news/audio/2024/may/07/india-election-whats-at-stake-for-democracy-under-modi-full-story-podcast",
+        "apiUrl": "https://content.guardianapis.com/australia-news/audio/2024/may/07/india-election-whats-at-stake-for-democracy-under-modi-full-story-podcast",
+        "fields": {
+          "standfirst": "<p>India’s mammoth election has kicked off with nearly a billion voters expected to head to the polls over six weeks.</p><p><strong>Reged Ahmad</strong> speaks to south Asia correspondent <strong>Hannah Ellis-Petersen</strong> about why prime minister Narendra Modi is popular yet divisive – and the international impact of the election</p><ul><li>You can support the Guardian at <a href=\"http://theguardian.com/fullstorysupport\">theguardian.com/fullstorysupport</a></li></ul>",
+          "trailText": "<strong>Reged Ahmad</strong> speaks to south Asia correspondent <strong>Hannah Ellis-Petersen</strong> about the logistical challenges of the mammoth election and why Narendra Modi is popular yet divisive",
+          "internalComposerCode": "6639b49c8f082c8a32eab7d2"
+        },
+        "tags": [
+          {
+            "id": "world/indian-elections-2014",
+            "type": "keyword",
+            "sectionId": "world",
+            "sectionName": "World news",
+            "webTitle": "India elections 2014",
+            "webUrl": "https://www.theguardian.com/world/indian-elections-2014",
+            "apiUrl": "https://content.guardianapis.com/world/indian-elections-2014",
+            "references": [],
+            "internalName": "India elections 2014 (News)"
+          },
+          {
+            "id": "world/india",
+            "type": "keyword",
+            "sectionId": "world",
+            "sectionName": "World news",
+            "webTitle": "India",
+            "webUrl": "https://www.theguardian.com/world/india",
+            "apiUrl": "https://content.guardianapis.com/world/india",
+            "references": [],
+            "internalName": "India (News)"
+          },
+          {
+            "id": "world/narendra-modi",
+            "type": "keyword",
+            "sectionId": "world",
+            "sectionName": "World news",
+            "webTitle": "Narendra Modi",
+            "webUrl": "https://www.theguardian.com/world/narendra-modi",
+            "apiUrl": "https://content.guardianapis.com/world/narendra-modi",
+            "references": [],
+            "internalName": "Narendra Modi"
+          },
+          {
+            "id": "world/south-and-central-asia",
+            "type": "keyword",
+            "sectionId": "world",
+            "sectionName": "World news",
+            "webTitle": "South and central Asia",
+            "webUrl": "https://www.theguardian.com/world/south-and-central-asia",
+            "apiUrl": "https://content.guardianapis.com/world/south-and-central-asia",
+            "references": [],
+            "internalName": "South and central Asia (News)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-6639b49c8f082c8a32eab7d2",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/05/07-25426-FS_INDIAN_ELECTION.mp3",
+                "typeData": {
+                  "source": "guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/05/07-25426-FS_INDIAN_ELECTION.mp3",
+                  "sizeInBytes": "34770065",
+                  "durationMinutes": "24",
+                  "durationSeconds": "8",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "343fe14156e38ef3c019e86d48fe259ada017e5a",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/343fe14156e38ef3c019e86d48fe259ada017e5a/0_209_4965_2980/master/4965.jpg",
+                "typeData": {
+                  "altText": "A supporter of India's ruling Bharatiya Janata party holds cutouts of Narendra Modi in Bengaluru, Karnataka",
+                  "credit": "Photograph: Navesh Chitrakar/Reuters",
+                  "photographer": "Navesh Chitrakar",
+                  "source": "Reuters",
+                  "width": "4965",
+                  "height": "2980",
+                  "secureFile": "https://media.guim.co.uk/343fe14156e38ef3c019e86d48fe259ada017e5a/0_209_4965_2980/master/4965.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "343fe14156e38ef3c019e86d48fe259ada017e5a",
+                  "imageType": "Photograph",
+                  "suppliersReference": "RC2BA7AOJEDG",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/343fe14156e38ef3c019e86d48fe259ada017e5a"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/343fe14156e38ef3c019e86d48fe259ada017e5a/0_209_4965_2980/4965.jpg",
+                "typeData": {
+                  "altText": "A supporter of India's ruling Bharatiya Janata party holds cutouts of Narendra Modi in Bengaluru, Karnataka",
+                  "credit": "Photograph: Navesh Chitrakar/Reuters",
+                  "photographer": "Navesh Chitrakar",
+                  "source": "Reuters",
+                  "width": "4965",
+                  "height": "2980",
+                  "secureFile": "https://media.guim.co.uk/343fe14156e38ef3c019e86d48fe259ada017e5a/0_209_4965_2980/4965.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "343fe14156e38ef3c019e86d48fe259ada017e5a",
+                  "imageType": "Photograph",
+                  "suppliersReference": "RC2BA7AOJEDG",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/343fe14156e38ef3c019e86d48fe259ada017e5a"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/343fe14156e38ef3c019e86d48fe259ada017e5a/0_209_4965_2980/500.jpg",
+                "typeData": {
+                  "altText": "A supporter of India's ruling Bharatiya Janata party holds cutouts of Narendra Modi in Bengaluru, Karnataka",
+                  "credit": "Photograph: Navesh Chitrakar/Reuters",
+                  "photographer": "Navesh Chitrakar",
+                  "source": "Reuters",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/343fe14156e38ef3c019e86d48fe259ada017e5a/0_209_4965_2980/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "343fe14156e38ef3c019e86d48fe259ada017e5a",
+                  "imageType": "Photograph",
+                  "suppliersReference": "RC2BA7AOJEDG",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/343fe14156e38ef3c019e86d48fe259ada017e5a"
+                }
+              }
+            ]
+          }
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/news",
+        "pillarName": "News"
+      },
+      {
+        "id": "australia-news/audio/2024/may/07/alleged-mushroom-murders-erin-patterson-faces-court-full-story-podcast",
+        "type": "audio",
+        "sectionId": "australia-news",
+        "sectionName": "Australia news",
+        "webPublicationDate": "2024-05-06T15:00:46Z",
+        "webTitle": "Alleged mushroom murders: Erin Patterson faces court – podcast",
+        "webUrl": "https://www.theguardian.com/australia-news/audio/2024/may/07/alleged-mushroom-murders-erin-patterson-faces-court-full-story-podcast",
+        "apiUrl": "https://content.guardianapis.com/australia-news/audio/2024/may/07/alleged-mushroom-murders-erin-patterson-faces-court-full-story-podcast",
+        "fields": {
+          "standfirst": "<p>In July 2023, Erin Patterson hosted four relatives for lunch in the Victorian town of Leongatha. The guests were served beef wellington – which police allege was laced with a deadly mushroom. </p><p>Patterson was charged with three counts of murder and five counts of attempted murder and is due to face court today. Courts and justice reporter <strong>Nino Bucci </strong>tells <strong>Nour Haydar </strong>about the latest developments in the case and why it has drawn intense media interest</p><ul><li>You can support the Guardian at <a href=\"http://theguardian.com/fullstorysupport\">theguardian.com/fullstorysupport</a></li></ul>",
+          "trailText": "<strong>Nino Bucci </strong>tells <strong>Nour Haydar </strong>about the months-long investigation into Victoria’s alleged mushroom murders and the latest court developments",
+          "internalComposerCode": "663487398f082dacd4220cb8"
+        },
+        "tags": [
+          {
+            "id": "australia-news/crime-australia",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Crime - Australia",
+            "webUrl": "https://www.theguardian.com/australia-news/crime-australia",
+            "apiUrl": "https://content.guardianapis.com/australia-news/crime-australia",
+            "references": [],
+            "description": "Latest news on crime in Australia from the Guardian",
+            "internalName": "Crime (Australia)"
+          },
+          {
+            "id": "australia-news/australia-news",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Australia news",
+            "webUrl": "https://www.theguardian.com/australia-news/australia-news",
+            "apiUrl": "https://content.guardianapis.com/australia-news/australia-news",
+            "references": [],
+            "internalName": "Australia (News)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-663487398f082dacd4220cb8",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/05/06-16434-FS_MUSHROOMS.mp3",
+                "typeData": {
+                  "source": "guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/05/06-16434-FS_MUSHROOMS.mp3",
+                  "sizeInBytes": "21646350",
+                  "durationMinutes": "15",
+                  "durationSeconds": "1",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "88f87136902566dd56e3462537885b664af059af",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/88f87136902566dd56e3462537885b664af059af/0_267_3500_2101/master/3500.jpg",
+                "typeData": {
+                  "altText": "In this courtroom sketch, Erin Patterson appears in Latrobe Valley magistrates court, Australia on 3 November 2023",
+                  "credit": "Photograph: Anita Lester/AP",
+                  "photographer": "Anita Lester",
+                  "source": "AP",
+                  "width": "3500",
+                  "height": "2101",
+                  "secureFile": "https://media.guim.co.uk/88f87136902566dd56e3462537885b664af059af/0_267_3500_2101/master/3500.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "88f87136902566dd56e3462537885b664af059af",
+                  "imageType": "Photograph",
+                  "suppliersReference": "f2bfa0e5-18d2-494b-8044-c1d34ce6d282",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/88f87136902566dd56e3462537885b664af059af"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/88f87136902566dd56e3462537885b664af059af/0_267_3500_2101/3500.jpg",
+                "typeData": {
+                  "altText": "In this courtroom sketch, Erin Patterson appears in Latrobe Valley magistrates court, Australia on 3 November 2023",
+                  "credit": "Photograph: Anita Lester/AP",
+                  "photographer": "Anita Lester",
+                  "source": "AP",
+                  "width": "3500",
+                  "height": "2101",
+                  "secureFile": "https://media.guim.co.uk/88f87136902566dd56e3462537885b664af059af/0_267_3500_2101/3500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "88f87136902566dd56e3462537885b664af059af",
+                  "imageType": "Photograph",
+                  "suppliersReference": "f2bfa0e5-18d2-494b-8044-c1d34ce6d282",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/88f87136902566dd56e3462537885b664af059af"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/88f87136902566dd56e3462537885b664af059af/0_267_3500_2101/500.jpg",
+                "typeData": {
+                  "altText": "In this courtroom sketch, Erin Patterson appears in Latrobe Valley magistrates court, Australia on 3 November 2023",
+                  "credit": "Photograph: Anita Lester/AP",
+                  "photographer": "Anita Lester",
+                  "source": "AP",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/88f87136902566dd56e3462537885b664af059af/0_267_3500_2101/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "88f87136902566dd56e3462537885b664af059af",
+                  "imageType": "Photograph",
+                  "suppliersReference": "f2bfa0e5-18d2-494b-8044-c1d34ce6d282",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/88f87136902566dd56e3462537885b664af059af"
+                }
+              }
+            ]
+          }
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/news",
+        "pillarName": "News"
+      },
+      {
+        "id": "australia-news/audio/2024/may/06/why-are-australian-schools-failing-children-with-disabilities-full-story-podcast",
+        "type": "audio",
+        "sectionId": "australia-news",
+        "sectionName": "Australia news",
+        "webPublicationDate": "2024-05-05T15:00:13Z",
+        "webTitle": "Why are Australian schools failing children with disabilities? - podcast",
+        "webUrl": "https://www.theguardian.com/australia-news/audio/2024/may/06/why-are-australian-schools-failing-children-with-disabilities-full-story-podcast",
+        "apiUrl": "https://content.guardianapis.com/australia-news/audio/2024/may/06/why-are-australian-schools-failing-children-with-disabilities-full-story-podcast",
+        "fields": {
+          "standfirst": "<p>The number of disabled students recognised as needing greater learning support has grown to almost 1 million nationally. But these children are increasingly being suspended from schools, including some as young as five years old. Investigative reporter <strong>Sarah Martin</strong> explains to <strong>Jane Lee</strong> how Australia’s education system has reached crisis point</p>",
+          "trailText": "Investigative reporter <strong>Sarah Martin</strong> explains to <strong>Jane Lee</strong> how the education system has reached crisis point",
+          "internalComposerCode": "6634405e8f082dacd4220ab7"
+        },
+        "tags": [
+          {
+            "id": "australia-news/australian-education",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Australian education",
+            "webUrl": "https://www.theguardian.com/australia-news/australian-education",
+            "apiUrl": "https://content.guardianapis.com/australia-news/australian-education",
+            "references": [],
+            "internalName": "Education (Australia)"
+          },
+          {
+            "id": "australia-news/australia-news",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Australia news",
+            "webUrl": "https://www.theguardian.com/australia-news/australia-news",
+            "apiUrl": "https://content.guardianapis.com/australia-news/australia-news",
+            "references": [],
+            "internalName": "Australia (News)"
+          },
+          {
+            "id": "society/disability",
+            "type": "keyword",
+            "sectionId": "society",
+            "sectionName": "Society",
+            "webTitle": "Disability",
+            "webUrl": "https://www.theguardian.com/society/disability",
+            "apiUrl": "https://content.guardianapis.com/society/disability",
+            "references": [],
+            "internalName": "Disability (Society)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-6634405e8f082dacd4220ab7",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/05/03-23893-FS_DisabilityEducation.mp3",
+                "typeData": {
+                  "source": "guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/05/03-23893-FS_DisabilityEducation.mp3",
+                  "sizeInBytes": "32577049",
+                  "durationMinutes": "22",
+                  "durationSeconds": "37",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "1ab3d6bd851ef1359628ab3533376f00806b7f41",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/1ab3d6bd851ef1359628ab3533376f00806b7f41/0_0_2500_1500/master/2500.jpg",
+                "typeData": {
+                  "altText": "Alicia Cook with her son Emerson",
+                  "credit": "Photograph: Sarah Rhodes/The Guardian",
+                  "photographer": "Sarah Rhodes",
+                  "source": "The Guardian",
+                  "width": "2500",
+                  "height": "1500",
+                  "secureFile": "https://media.guim.co.uk/1ab3d6bd851ef1359628ab3533376f00806b7f41/0_0_2500_1500/master/2500.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "1ab3d6bd851ef1359628ab3533376f00806b7f41",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/1ab3d6bd851ef1359628ab3533376f00806b7f41"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/1ab3d6bd851ef1359628ab3533376f00806b7f41/0_0_2500_1500/2500.jpg",
+                "typeData": {
+                  "altText": "Alicia Cook with her son Emerson",
+                  "credit": "Photograph: Sarah Rhodes/The Guardian",
+                  "photographer": "Sarah Rhodes",
+                  "source": "The Guardian",
+                  "width": "2500",
+                  "height": "1500",
+                  "secureFile": "https://media.guim.co.uk/1ab3d6bd851ef1359628ab3533376f00806b7f41/0_0_2500_1500/2500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "1ab3d6bd851ef1359628ab3533376f00806b7f41",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/1ab3d6bd851ef1359628ab3533376f00806b7f41"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/1ab3d6bd851ef1359628ab3533376f00806b7f41/0_0_2500_1500/500.jpg",
+                "typeData": {
+                  "altText": "Alicia Cook with her son Emerson",
+                  "credit": "Photograph: Sarah Rhodes/The Guardian",
+                  "photographer": "Sarah Rhodes",
+                  "source": "The Guardian",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/1ab3d6bd851ef1359628ab3533376f00806b7f41/0_0_2500_1500/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "1ab3d6bd851ef1359628ab3533376f00806b7f41",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/1ab3d6bd851ef1359628ab3533376f00806b7f41"
+                }
+              }
+            ]
+          }
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/news",
+        "pillarName": "News"
+      },
+      {
+        "id": "australia-news/audio/2024/may/02/newsroom-edition-political-lessons-from-scott-morrisons-faith-full-story-podcast",
+        "type": "audio",
+        "sectionId": "australia-news",
+        "sectionName": "Australia news",
+        "webPublicationDate": "2024-05-02T15:00:13Z",
+        "webTitle": "Newsroom edition: Scott Morrison’s memoir and the role for faith in politics – podcast",
+        "webUrl": "https://www.theguardian.com/australia-news/audio/2024/may/02/newsroom-edition-political-lessons-from-scott-morrisons-faith-full-story-podcast",
+        "apiUrl": "https://content.guardianapis.com/australia-news/audio/2024/may/02/newsroom-edition-political-lessons-from-scott-morrisons-faith-full-story-podcast",
+        "fields": {
+          "standfirst": "<p>In Australia – a multifaith and sometimes agnostic country – what role does faith play in the decision-making of those who run the country? With the upcoming release of his book, <strong>Plans For Your Good: A Prime Minister’s Testimony of God’s Faithfulness</strong>, Scott Morrison has placed his faith front and centre. But is this something new? Or has religion always been a part of Australia’s political democracy?</p><p><strong>Bridie Jabour</strong> speaks with editor in chief <strong>Lenore Taylor</strong> and deputy editor <strong>Patrick Keneally</strong> on the nuanced relationship between faith and politics</p><ul><li>You can support the Guardian at <a href=\"http://theguardian.com/fullstorysupport\">theguardian.com/fullstorysupport</a></li></ul>",
+          "trailText": "<strong>Bridie Jabour</strong> speaks with editor in chief <strong>Lenore Taylor</strong> and deputy editor <strong>Patrick Keneally</strong> on the nuanced relationship between faith and politics",
+          "internalComposerCode": "66331a978f08cb0a1ccaaa62"
+        },
+        "tags": [
+          {
+            "id": "australia-news/australian-politics",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Australian politics",
+            "webUrl": "https://www.theguardian.com/australia-news/australian-politics",
+            "apiUrl": "https://content.guardianapis.com/australia-news/australian-politics",
+            "references": [],
+            "internalName": "Australian politics"
+          },
+          {
+            "id": "australia-news/scott-morrison",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Scott Morrison",
+            "webUrl": "https://www.theguardian.com/australia-news/scott-morrison",
+            "apiUrl": "https://content.guardianapis.com/australia-news/scott-morrison",
+            "references": [],
+            "internalName": "Scott Morrison"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-66331a978f08cb0a1ccaaa62",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/05/02-25348-FS_FS_Religion_ch_020524_1700.mp3",
+                "typeData": {
+                  "source": "guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/05/02-25348-FS_FS_Religion_ch_020524_1700.mp3",
+                  "sizeInBytes": "32066089",
+                  "durationMinutes": "22",
+                  "durationSeconds": "16",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "ec5daa5e78456158616f8a58710e402c05e51674",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/ec5daa5e78456158616f8a58710e402c05e51674/922_0_3286_1972/master/3286.jpg",
+                "typeData": {
+                  "altText": "Former Australian Prime Minister Scott Morrison and wife Jenny sing during an Easter Sunday service at Horizon Church, in Sydney, in 2019.",
+                  "credit": "Photograph: Mick Tsikas/AAP",
+                  "photographer": "Mick Tsikas",
+                  "source": "AAP",
+                  "width": "3286",
+                  "height": "1972",
+                  "secureFile": "https://media.guim.co.uk/ec5daa5e78456158616f8a58710e402c05e51674/922_0_3286_1972/master/3286.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "ec5daa5e78456158616f8a58710e402c05e51674",
+                  "imageType": "Photograph",
+                  "suppliersReference": "AAP",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/ec5daa5e78456158616f8a58710e402c05e51674"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/ec5daa5e78456158616f8a58710e402c05e51674/922_0_3286_1972/3286.jpg",
+                "typeData": {
+                  "altText": "Former Australian Prime Minister Scott Morrison and wife Jenny sing during an Easter Sunday service at Horizon Church, in Sydney, in 2019.",
+                  "credit": "Photograph: Mick Tsikas/AAP",
+                  "photographer": "Mick Tsikas",
+                  "source": "AAP",
+                  "width": "3286",
+                  "height": "1972",
+                  "secureFile": "https://media.guim.co.uk/ec5daa5e78456158616f8a58710e402c05e51674/922_0_3286_1972/3286.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "ec5daa5e78456158616f8a58710e402c05e51674",
+                  "imageType": "Photograph",
+                  "suppliersReference": "AAP",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/ec5daa5e78456158616f8a58710e402c05e51674"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/ec5daa5e78456158616f8a58710e402c05e51674/922_0_3286_1972/500.jpg",
+                "typeData": {
+                  "altText": "Former Australian Prime Minister Scott Morrison and wife Jenny sing during an Easter Sunday service at Horizon Church, in Sydney, in 2019.",
+                  "credit": "Photograph: Mick Tsikas/AAP",
+                  "photographer": "Mick Tsikas",
+                  "source": "AAP",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/ec5daa5e78456158616f8a58710e402c05e51674/922_0_3286_1972/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "ec5daa5e78456158616f8a58710e402c05e51674",
+                  "imageType": "Photograph",
+                  "suppliersReference": "AAP",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/ec5daa5e78456158616f8a58710e402c05e51674"
+                }
+              }
+            ]
+          }
+        ],
+        "isHosted": false,
+        "pillarId": "pillar/news",
+        "pillarName": "News"
+      }
+    ],
+    "leadContent": [
+      {
+        "id": "australia-news/audio/2024/may/07/india-election-whats-at-stake-for-democracy-under-modi-full-story-podcast",
+        "type": "audio",
+        "sectionId": "australia-news",
+        "sectionName": "Australia news",
+        "webPublicationDate": "2024-05-07T15:00:19Z",
+        "webTitle": "India election: what’s at stake for democracy under Modi? - podcast",
+        "webUrl": "https://www.theguardian.com/australia-news/audio/2024/may/07/india-election-whats-at-stake-for-democracy-under-modi-full-story-podcast",
+        "apiUrl": "https://content.guardianapis.com/australia-news/audio/2024/may/07/india-election-whats-at-stake-for-democracy-under-modi-full-story-podcast",
+        "fields": {
+          "standfirst": "<p>India’s mammoth election has kicked off with nearly a billion voters expected to head to the polls over six weeks.</p><p><strong>Reged Ahmad</strong> speaks to south Asia correspondent <strong>Hannah Ellis-Petersen</strong> about why prime minister Narendra Modi is popular yet divisive – and the international impact of the election</p><ul><li>You can support the Guardian at <a href=\"http://theguardian.com/fullstorysupport\">theguardian.com/fullstorysupport</a></li></ul>",
+          "trailText": "<strong>Reged Ahmad</strong> speaks to south Asia correspondent <strong>Hannah Ellis-Petersen</strong> about the logistical challenges of the mammoth election and why Narendra Modi is popular yet divisive",
+          "internalComposerCode": "6639b49c8f082c8a32eab7d2"
+        },
+        "tags": [
+          {
+            "id": "world/indian-elections-2014",
+            "type": "keyword",
+            "sectionId": "world",
+            "sectionName": "World news",
+            "webTitle": "India elections 2014",
+            "webUrl": "https://www.theguardian.com/world/indian-elections-2014",
+            "apiUrl": "https://content.guardianapis.com/world/indian-elections-2014",
+            "references": [],
+            "internalName": "India elections 2014 (News)"
+          },
+          {
+            "id": "world/india",
+            "type": "keyword",
+            "sectionId": "world",
+            "sectionName": "World news",
+            "webTitle": "India",
+            "webUrl": "https://www.theguardian.com/world/india",
+            "apiUrl": "https://content.guardianapis.com/world/india",
+            "references": [],
+            "internalName": "India (News)"
+          },
+          {
+            "id": "world/narendra-modi",
+            "type": "keyword",
+            "sectionId": "world",
+            "sectionName": "World news",
+            "webTitle": "Narendra Modi",
+            "webUrl": "https://www.theguardian.com/world/narendra-modi",
+            "apiUrl": "https://content.guardianapis.com/world/narendra-modi",
+            "references": [],
+            "internalName": "Narendra Modi"
+          },
+          {
+            "id": "world/south-and-central-asia",
+            "type": "keyword",
+            "sectionId": "world",
+            "sectionName": "World news",
+            "webTitle": "South and central Asia",
+            "webUrl": "https://www.theguardian.com/world/south-and-central-asia",
+            "apiUrl": "https://content.guardianapis.com/world/south-and-central-asia",
+            "references": [],
+            "internalName": "South and central Asia (News)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-6639b49c8f082c8a32eab7d2",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/05/07-25426-FS_INDIAN_ELECTION.mp3",
+                "typeData": {
+                  "source": "guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/05/07-25426-FS_INDIAN_ELECTION.mp3",
+                  "sizeInBytes": "34770065",
+                  "durationMinutes": "24",
+                  "durationSeconds": "8",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "343fe14156e38ef3c019e86d48fe259ada017e5a",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/343fe14156e38ef3c019e86d48fe259ada017e5a/0_209_4965_2980/master/4965.jpg",
+                "typeData": {
+                  "altText": "A supporter of India's ruling Bharatiya Janata party holds cutouts of Narendra Modi in Bengaluru, Karnataka",
+                  "credit": "Photograph: Navesh Chitrakar/Reuters",
+                  "photographer": "Navesh Chitrakar",
+                  "source": "Reuters",
+                  "width": "4965",
+                  "height": "2980",
+                  "secureFile": "https://media.guim.co.uk/343fe14156e38ef3c019e86d48fe259ada017e5a/0_209_4965_2980/master/4965.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "343fe14156e38ef3c019e86d48fe259ada017e5a",
+                  "imageType": "Photograph",
+                  "suppliersReference": "RC2BA7AOJEDG",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/343fe14156e38ef3c019e86d48fe259ada017e5a"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/343fe14156e38ef3c019e86d48fe259ada017e5a/0_209_4965_2980/4965.jpg",
+                "typeData": {
+                  "altText": "A supporter of India's ruling Bharatiya Janata party holds cutouts of Narendra Modi in Bengaluru, Karnataka",
+                  "credit": "Photograph: Navesh Chitrakar/Reuters",
+                  "photographer": "Navesh Chitrakar",
+                  "source": "Reuters",
+                  "width": "4965",
+                  "height": "2980",
+                  "secureFile": "https://media.guim.co.uk/343fe14156e38ef3c019e86d48fe259ada017e5a/0_209_4965_2980/4965.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "343fe14156e38ef3c019e86d48fe259ada017e5a",
+                  "imageType": "Photograph",
+                  "suppliersReference": "RC2BA7AOJEDG",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/343fe14156e38ef3c019e86d48fe259ada017e5a"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/343fe14156e38ef3c019e86d48fe259ada017e5a/0_209_4965_2980/500.jpg",
+                "typeData": {
+                  "altText": "A supporter of India's ruling Bharatiya Janata party holds cutouts of Narendra Modi in Bengaluru, Karnataka",
+                  "credit": "Photograph: Navesh Chitrakar/Reuters",
+                  "photographer": "Navesh Chitrakar",
+                  "source": "Reuters",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/343fe14156e38ef3c019e86d48fe259ada017e5a/0_209_4965_2980/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "343fe14156e38ef3c019e86d48fe259ada017e5a",
+                  "imageType": "Photograph",
+                  "suppliersReference": "RC2BA7AOJEDG",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/343fe14156e38ef3c019e86d48fe259ada017e5a"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/news",
+        "pillarName": "News"
+      },
+      {
+        "id": "australia-news/audio/2024/may/07/alleged-mushroom-murders-erin-patterson-faces-court-full-story-podcast",
+        "type": "audio",
+        "sectionId": "australia-news",
+        "sectionName": "Australia news",
+        "webPublicationDate": "2024-05-06T15:00:46Z",
+        "webTitle": "Alleged mushroom murders: Erin Patterson faces court – podcast",
+        "webUrl": "https://www.theguardian.com/australia-news/audio/2024/may/07/alleged-mushroom-murders-erin-patterson-faces-court-full-story-podcast",
+        "apiUrl": "https://content.guardianapis.com/australia-news/audio/2024/may/07/alleged-mushroom-murders-erin-patterson-faces-court-full-story-podcast",
+        "fields": {
+          "standfirst": "<p>In July 2023, Erin Patterson hosted four relatives for lunch in the Victorian town of Leongatha. The guests were served beef wellington – which police allege was laced with a deadly mushroom. </p><p>Patterson was charged with three counts of murder and five counts of attempted murder and is due to face court today. Courts and justice reporter <strong>Nino Bucci </strong>tells <strong>Nour Haydar </strong>about the latest developments in the case and why it has drawn intense media interest</p><ul><li>You can support the Guardian at <a href=\"http://theguardian.com/fullstorysupport\">theguardian.com/fullstorysupport</a></li></ul>",
+          "trailText": "<strong>Nino Bucci </strong>tells <strong>Nour Haydar </strong>about the months-long investigation into Victoria’s alleged mushroom murders and the latest court developments",
+          "internalComposerCode": "663487398f082dacd4220cb8"
+        },
+        "tags": [
+          {
+            "id": "australia-news/crime-australia",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Crime - Australia",
+            "webUrl": "https://www.theguardian.com/australia-news/crime-australia",
+            "apiUrl": "https://content.guardianapis.com/australia-news/crime-australia",
+            "references": [],
+            "description": "Latest news on crime in Australia from the Guardian",
+            "internalName": "Crime (Australia)"
+          },
+          {
+            "id": "australia-news/australia-news",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Australia news",
+            "webUrl": "https://www.theguardian.com/australia-news/australia-news",
+            "apiUrl": "https://content.guardianapis.com/australia-news/australia-news",
+            "references": [],
+            "internalName": "Australia (News)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-663487398f082dacd4220cb8",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/05/06-16434-FS_MUSHROOMS.mp3",
+                "typeData": {
+                  "source": "guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/05/06-16434-FS_MUSHROOMS.mp3",
+                  "sizeInBytes": "21646350",
+                  "durationMinutes": "15",
+                  "durationSeconds": "1",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "88f87136902566dd56e3462537885b664af059af",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/88f87136902566dd56e3462537885b664af059af/0_267_3500_2101/master/3500.jpg",
+                "typeData": {
+                  "altText": "In this courtroom sketch, Erin Patterson appears in Latrobe Valley magistrates court, Australia on 3 November 2023",
+                  "credit": "Photograph: Anita Lester/AP",
+                  "photographer": "Anita Lester",
+                  "source": "AP",
+                  "width": "3500",
+                  "height": "2101",
+                  "secureFile": "https://media.guim.co.uk/88f87136902566dd56e3462537885b664af059af/0_267_3500_2101/master/3500.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "88f87136902566dd56e3462537885b664af059af",
+                  "imageType": "Photograph",
+                  "suppliersReference": "f2bfa0e5-18d2-494b-8044-c1d34ce6d282",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/88f87136902566dd56e3462537885b664af059af"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/88f87136902566dd56e3462537885b664af059af/0_267_3500_2101/3500.jpg",
+                "typeData": {
+                  "altText": "In this courtroom sketch, Erin Patterson appears in Latrobe Valley magistrates court, Australia on 3 November 2023",
+                  "credit": "Photograph: Anita Lester/AP",
+                  "photographer": "Anita Lester",
+                  "source": "AP",
+                  "width": "3500",
+                  "height": "2101",
+                  "secureFile": "https://media.guim.co.uk/88f87136902566dd56e3462537885b664af059af/0_267_3500_2101/3500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "88f87136902566dd56e3462537885b664af059af",
+                  "imageType": "Photograph",
+                  "suppliersReference": "f2bfa0e5-18d2-494b-8044-c1d34ce6d282",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/88f87136902566dd56e3462537885b664af059af"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/88f87136902566dd56e3462537885b664af059af/0_267_3500_2101/500.jpg",
+                "typeData": {
+                  "altText": "In this courtroom sketch, Erin Patterson appears in Latrobe Valley magistrates court, Australia on 3 November 2023",
+                  "credit": "Photograph: Anita Lester/AP",
+                  "photographer": "Anita Lester",
+                  "source": "AP",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/88f87136902566dd56e3462537885b664af059af/0_267_3500_2101/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "88f87136902566dd56e3462537885b664af059af",
+                  "imageType": "Photograph",
+                  "suppliersReference": "f2bfa0e5-18d2-494b-8044-c1d34ce6d282",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/88f87136902566dd56e3462537885b664af059af"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/news",
+        "pillarName": "News"
+      },
+      {
+        "id": "australia-news/audio/2024/may/06/why-are-australian-schools-failing-children-with-disabilities-full-story-podcast",
+        "type": "audio",
+        "sectionId": "australia-news",
+        "sectionName": "Australia news",
+        "webPublicationDate": "2024-05-05T15:00:13Z",
+        "webTitle": "Why are Australian schools failing children with disabilities? - podcast",
+        "webUrl": "https://www.theguardian.com/australia-news/audio/2024/may/06/why-are-australian-schools-failing-children-with-disabilities-full-story-podcast",
+        "apiUrl": "https://content.guardianapis.com/australia-news/audio/2024/may/06/why-are-australian-schools-failing-children-with-disabilities-full-story-podcast",
+        "fields": {
+          "standfirst": "<p>The number of disabled students recognised as needing greater learning support has grown to almost 1 million nationally. But these children are increasingly being suspended from schools, including some as young as five years old. Investigative reporter <strong>Sarah Martin</strong> explains to <strong>Jane Lee</strong> how Australia’s education system has reached crisis point</p>",
+          "trailText": "Investigative reporter <strong>Sarah Martin</strong> explains to <strong>Jane Lee</strong> how the education system has reached crisis point",
+          "internalComposerCode": "6634405e8f082dacd4220ab7"
+        },
+        "tags": [
+          {
+            "id": "australia-news/australian-education",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Australian education",
+            "webUrl": "https://www.theguardian.com/australia-news/australian-education",
+            "apiUrl": "https://content.guardianapis.com/australia-news/australian-education",
+            "references": [],
+            "internalName": "Education (Australia)"
+          },
+          {
+            "id": "australia-news/australia-news",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Australia news",
+            "webUrl": "https://www.theguardian.com/australia-news/australia-news",
+            "apiUrl": "https://content.guardianapis.com/australia-news/australia-news",
+            "references": [],
+            "internalName": "Australia (News)"
+          },
+          {
+            "id": "society/disability",
+            "type": "keyword",
+            "sectionId": "society",
+            "sectionName": "Society",
+            "webTitle": "Disability",
+            "webUrl": "https://www.theguardian.com/society/disability",
+            "apiUrl": "https://content.guardianapis.com/society/disability",
+            "references": [],
+            "internalName": "Disability (Society)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-6634405e8f082dacd4220ab7",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/05/03-23893-FS_DisabilityEducation.mp3",
+                "typeData": {
+                  "source": "guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/05/03-23893-FS_DisabilityEducation.mp3",
+                  "sizeInBytes": "32577049",
+                  "durationMinutes": "22",
+                  "durationSeconds": "37",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "1ab3d6bd851ef1359628ab3533376f00806b7f41",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/1ab3d6bd851ef1359628ab3533376f00806b7f41/0_0_2500_1500/master/2500.jpg",
+                "typeData": {
+                  "altText": "Alicia Cook with her son Emerson",
+                  "credit": "Photograph: Sarah Rhodes/The Guardian",
+                  "photographer": "Sarah Rhodes",
+                  "source": "The Guardian",
+                  "width": "2500",
+                  "height": "1500",
+                  "secureFile": "https://media.guim.co.uk/1ab3d6bd851ef1359628ab3533376f00806b7f41/0_0_2500_1500/master/2500.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "1ab3d6bd851ef1359628ab3533376f00806b7f41",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/1ab3d6bd851ef1359628ab3533376f00806b7f41"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/1ab3d6bd851ef1359628ab3533376f00806b7f41/0_0_2500_1500/2500.jpg",
+                "typeData": {
+                  "altText": "Alicia Cook with her son Emerson",
+                  "credit": "Photograph: Sarah Rhodes/The Guardian",
+                  "photographer": "Sarah Rhodes",
+                  "source": "The Guardian",
+                  "width": "2500",
+                  "height": "1500",
+                  "secureFile": "https://media.guim.co.uk/1ab3d6bd851ef1359628ab3533376f00806b7f41/0_0_2500_1500/2500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "1ab3d6bd851ef1359628ab3533376f00806b7f41",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/1ab3d6bd851ef1359628ab3533376f00806b7f41"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/1ab3d6bd851ef1359628ab3533376f00806b7f41/0_0_2500_1500/500.jpg",
+                "typeData": {
+                  "altText": "Alicia Cook with her son Emerson",
+                  "credit": "Photograph: Sarah Rhodes/The Guardian",
+                  "photographer": "Sarah Rhodes",
+                  "source": "The Guardian",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/1ab3d6bd851ef1359628ab3533376f00806b7f41/0_0_2500_1500/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "1ab3d6bd851ef1359628ab3533376f00806b7f41",
+                  "imageType": "Photograph",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/1ab3d6bd851ef1359628ab3533376f00806b7f41"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/news",
+        "pillarName": "News"
+      },
+      {
+        "id": "australia-news/audio/2024/may/02/newsroom-edition-political-lessons-from-scott-morrisons-faith-full-story-podcast",
+        "type": "audio",
+        "sectionId": "australia-news",
+        "sectionName": "Australia news",
+        "webPublicationDate": "2024-05-02T15:00:13Z",
+        "webTitle": "Newsroom edition: Scott Morrison’s memoir and the role for faith in politics – podcast",
+        "webUrl": "https://www.theguardian.com/australia-news/audio/2024/may/02/newsroom-edition-political-lessons-from-scott-morrisons-faith-full-story-podcast",
+        "apiUrl": "https://content.guardianapis.com/australia-news/audio/2024/may/02/newsroom-edition-political-lessons-from-scott-morrisons-faith-full-story-podcast",
+        "fields": {
+          "standfirst": "<p>In Australia – a multifaith and sometimes agnostic country – what role does faith play in the decision-making of those who run the country? With the upcoming release of his book, <strong>Plans For Your Good: A Prime Minister’s Testimony of God’s Faithfulness</strong>, Scott Morrison has placed his faith front and centre. But is this something new? Or has religion always been a part of Australia’s political democracy?</p><p><strong>Bridie Jabour</strong> speaks with editor in chief <strong>Lenore Taylor</strong> and deputy editor <strong>Patrick Keneally</strong> on the nuanced relationship between faith and politics</p><ul><li>You can support the Guardian at <a href=\"http://theguardian.com/fullstorysupport\">theguardian.com/fullstorysupport</a></li></ul>",
+          "trailText": "<strong>Bridie Jabour</strong> speaks with editor in chief <strong>Lenore Taylor</strong> and deputy editor <strong>Patrick Keneally</strong> on the nuanced relationship between faith and politics",
+          "internalComposerCode": "66331a978f08cb0a1ccaaa62"
+        },
+        "tags": [
+          {
+            "id": "australia-news/australian-politics",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Australian politics",
+            "webUrl": "https://www.theguardian.com/australia-news/australian-politics",
+            "apiUrl": "https://content.guardianapis.com/australia-news/australian-politics",
+            "references": [],
+            "internalName": "Australian politics"
+          },
+          {
+            "id": "australia-news/scott-morrison",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Scott Morrison",
+            "webUrl": "https://www.theguardian.com/australia-news/scott-morrison",
+            "apiUrl": "https://content.guardianapis.com/australia-news/scott-morrison",
+            "references": [],
+            "internalName": "Scott Morrison"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-66331a978f08cb0a1ccaaa62",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/05/02-25348-FS_FS_Religion_ch_020524_1700.mp3",
+                "typeData": {
+                  "source": "guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/05/02-25348-FS_FS_Religion_ch_020524_1700.mp3",
+                  "sizeInBytes": "32066089",
+                  "durationMinutes": "22",
+                  "durationSeconds": "16",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "ec5daa5e78456158616f8a58710e402c05e51674",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/ec5daa5e78456158616f8a58710e402c05e51674/922_0_3286_1972/master/3286.jpg",
+                "typeData": {
+                  "altText": "Former Australian Prime Minister Scott Morrison and wife Jenny sing during an Easter Sunday service at Horizon Church, in Sydney, in 2019.",
+                  "credit": "Photograph: Mick Tsikas/AAP",
+                  "photographer": "Mick Tsikas",
+                  "source": "AAP",
+                  "width": "3286",
+                  "height": "1972",
+                  "secureFile": "https://media.guim.co.uk/ec5daa5e78456158616f8a58710e402c05e51674/922_0_3286_1972/master/3286.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "ec5daa5e78456158616f8a58710e402c05e51674",
+                  "imageType": "Photograph",
+                  "suppliersReference": "AAP",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/ec5daa5e78456158616f8a58710e402c05e51674"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/ec5daa5e78456158616f8a58710e402c05e51674/922_0_3286_1972/3286.jpg",
+                "typeData": {
+                  "altText": "Former Australian Prime Minister Scott Morrison and wife Jenny sing during an Easter Sunday service at Horizon Church, in Sydney, in 2019.",
+                  "credit": "Photograph: Mick Tsikas/AAP",
+                  "photographer": "Mick Tsikas",
+                  "source": "AAP",
+                  "width": "3286",
+                  "height": "1972",
+                  "secureFile": "https://media.guim.co.uk/ec5daa5e78456158616f8a58710e402c05e51674/922_0_3286_1972/3286.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "ec5daa5e78456158616f8a58710e402c05e51674",
+                  "imageType": "Photograph",
+                  "suppliersReference": "AAP",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/ec5daa5e78456158616f8a58710e402c05e51674"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/ec5daa5e78456158616f8a58710e402c05e51674/922_0_3286_1972/500.jpg",
+                "typeData": {
+                  "altText": "Former Australian Prime Minister Scott Morrison and wife Jenny sing during an Easter Sunday service at Horizon Church, in Sydney, in 2019.",
+                  "credit": "Photograph: Mick Tsikas/AAP",
+                  "photographer": "Mick Tsikas",
+                  "source": "AAP",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/ec5daa5e78456158616f8a58710e402c05e51674/922_0_3286_1972/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "ec5daa5e78456158616f8a58710e402c05e51674",
+                  "imageType": "Photograph",
+                  "suppliersReference": "AAP",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/ec5daa5e78456158616f8a58710e402c05e51674"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/news",
+        "pillarName": "News"
+      },
+      {
+        "id": "australia-news/audio/2024/may/01/is-stubborn-inflation-taking-away-any-hope-for-an-interest-rate-cut-full-story-podcast",
+        "type": "audio",
+        "sectionId": "australia-news",
+        "sectionName": "Australia news",
+        "webPublicationDate": "2024-05-01T15:00:33Z",
+        "webTitle": "Is stubborn inflation taking away any hope for an interest rate cut? – podcast",
+        "webUrl": "https://www.theguardian.com/australia-news/audio/2024/may/01/is-stubborn-inflation-taking-away-any-hope-for-an-interest-rate-cut-full-story-podcast",
+        "apiUrl": "https://content.guardianapis.com/australia-news/audio/2024/may/01/is-stubborn-inflation-taking-away-any-hope-for-an-interest-rate-cut-full-story-podcast",
+        "fields": {
+          "standfirst": "<p>Rising education, health and rental costs have kept inflation higher than expected this year. Economics correspondent Peter Hannam tells Nour Haydar what the Reserve Bank’s reaction might be – are all hopes of an interest rate cut this year gone? And what does this mean for any cost of living relief the government might be considering?</p>",
+          "trailText": "Economics correspondent Peter Hannam tells Nour Haydar what the Reserve Bank’s reaction might be",
+          "internalComposerCode": "6631c74d8f08df7ec2bd9be4"
+        },
+        "tags": [
+          {
+            "id": "australia-news/reserve-bank-of-australia",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Reserve Bank of Australia",
+            "webUrl": "https://www.theguardian.com/australia-news/reserve-bank-of-australia",
+            "apiUrl": "https://content.guardianapis.com/australia-news/reserve-bank-of-australia",
+            "references": [],
+            "description": "Latest news on the Reserve Bank of Australia from the Guardian",
+            "internalName": "Reserve Bank of Australia"
+          },
+          {
+            "id": "business/inflation",
+            "type": "keyword",
+            "sectionId": "business",
+            "sectionName": "Business",
+            "webTitle": "Inflation",
+            "webUrl": "https://www.theguardian.com/business/inflation",
+            "apiUrl": "https://content.guardianapis.com/business/inflation",
+            "references": [],
+            "internalName": "Inflation (Business)"
+          },
+          {
+            "id": "australia-news/interest-rates-australia",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Interest rates",
+            "webUrl": "https://www.theguardian.com/australia-news/interest-rates-australia",
+            "apiUrl": "https://content.guardianapis.com/australia-news/interest-rates-australia",
+            "references": [],
+            "internalName": "Interest rates (Australia)"
+          },
+          {
+            "id": "business/australia-economy",
+            "type": "keyword",
+            "sectionId": "business",
+            "sectionName": "Business",
+            "webTitle": "Australian economy",
+            "webUrl": "https://www.theguardian.com/business/australia-economy",
+            "apiUrl": "https://content.guardianapis.com/business/australia-economy",
+            "references": [],
+            "internalName": "Australian economy"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-6631c74d8f08df7ec2bd9be4",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/05/01-22317-fs_economics_.mp3",
+                "typeData": {
+                  "source": "podcast",
+                  "secureFile": "https://audio.guim.co.uk/2024/05/01-22317-fs_economics_.mp3",
+                  "sizeInBytes": "20925501",
+                  "durationMinutes": "14",
+                  "durationSeconds": "31",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "c2884539b95352a5fa5bea91059024f2b7cf8931",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/c2884539b95352a5fa5bea91059024f2b7cf8931/252_764_7188_4313/master/7188.jpg",
+                "typeData": {
+                  "altText": "The Reserve Bank of Australia headquaters in Sydney, Tuesday, October 4, 2022. The Reserve Bank of Australia board holds its monthly meeting ahead of an announcement on interest rates. (AAP Image/Dean Lewins) NO ARCHIVING",
+                  "credit": "Photograph: Dean Lewins/AAP",
+                  "photographer": "Dean Lewins",
+                  "source": "AAP",
+                  "width": "7188",
+                  "height": "4313",
+                  "secureFile": "https://media.guim.co.uk/c2884539b95352a5fa5bea91059024f2b7cf8931/252_764_7188_4313/master/7188.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "c2884539b95352a5fa5bea91059024f2b7cf8931",
+                  "imageType": "Photograph",
+                  "suppliersReference": "633b45cdefe1bd46c725a75e",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/c2884539b95352a5fa5bea91059024f2b7cf8931"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/c2884539b95352a5fa5bea91059024f2b7cf8931/252_764_7188_4313/7188.jpg",
+                "typeData": {
+                  "altText": "The Reserve Bank of Australia headquaters in Sydney, Tuesday, October 4, 2022. The Reserve Bank of Australia board holds its monthly meeting ahead of an announcement on interest rates. (AAP Image/Dean Lewins) NO ARCHIVING",
+                  "credit": "Photograph: Dean Lewins/AAP",
+                  "photographer": "Dean Lewins",
+                  "source": "AAP",
+                  "width": "7188",
+                  "height": "4313",
+                  "secureFile": "https://media.guim.co.uk/c2884539b95352a5fa5bea91059024f2b7cf8931/252_764_7188_4313/7188.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "c2884539b95352a5fa5bea91059024f2b7cf8931",
+                  "imageType": "Photograph",
+                  "suppliersReference": "633b45cdefe1bd46c725a75e",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/c2884539b95352a5fa5bea91059024f2b7cf8931"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/c2884539b95352a5fa5bea91059024f2b7cf8931/252_764_7188_4313/500.jpg",
+                "typeData": {
+                  "altText": "The Reserve Bank of Australia headquaters in Sydney, Tuesday, October 4, 2022. The Reserve Bank of Australia board holds its monthly meeting ahead of an announcement on interest rates. (AAP Image/Dean Lewins) NO ARCHIVING",
+                  "credit": "Photograph: Dean Lewins/AAP",
+                  "photographer": "Dean Lewins",
+                  "source": "AAP",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/c2884539b95352a5fa5bea91059024f2b7cf8931/252_764_7188_4313/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "c2884539b95352a5fa5bea91059024f2b7cf8931",
+                  "imageType": "Photograph",
+                  "suppliersReference": "633b45cdefe1bd46c725a75e",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/c2884539b95352a5fa5bea91059024f2b7cf8931"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/news",
+        "pillarName": "News"
+      },
+      {
+        "id": "australia-news/audio/2024/apr/30/the-fringe-groups-taking-an-interest-in-queenslands-council-elections-full-story-podcast",
+        "type": "audio",
+        "sectionId": "australia-news",
+        "sectionName": "Australia news",
+        "webPublicationDate": "2024-04-30T15:00:34Z",
+        "webTitle": "The fringe groups taking an interest in Queensland’s council elections – podcast",
+        "webUrl": "https://www.theguardian.com/australia-news/audio/2024/apr/30/the-fringe-groups-taking-an-interest-in-queenslands-council-elections-full-story-podcast",
+        "apiUrl": "https://content.guardianapis.com/australia-news/audio/2024/apr/30/the-fringe-groups-taking-an-interest-in-queenslands-council-elections-full-story-podcast",
+        "fields": {
+          "standfirst": "<p>My Place emerged from the highly vocal Covid-19 anti-lockdown protests. It’s a network which reportedly has thousands of members and is predominantly active in Facebook community groups. Some of the ideas that these groups believe are that vaccines are deadly, fluoride in water is dangerous and 5G is a threat.</p><p>Lately My Place has been taking its ideologies offline and into local government, with some groups allegedly playing a role in supporting candidates in  Queensland council elections.</p><p>So with the Queensland state election coming up in October, what might be the potential impact of groups such as My Place on the polling results?</p><p>You can support the Guardian at <a href=\"http://theguardian.com/fullstorysupport\">theguardian.com/fullstorysupport</a></p><p></p>",
+          "trailText": "My Place has been taking its ideologies offline and into local government",
+          "internalComposerCode": "6628862a8f0839cf006b1636"
+        },
+        "tags": [
+          {
+            "id": "australia-news/queensland-politics",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Queensland politics",
+            "webUrl": "https://www.theguardian.com/australia-news/queensland-politics",
+            "apiUrl": "https://content.guardianapis.com/australia-news/queensland-politics",
+            "references": [],
+            "description": "Latest news and comment on Queensland politics ",
+            "internalName": "Queensland politics"
+          },
+          {
+            "id": "australia-news/australia-news",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Australia news",
+            "webUrl": "https://www.theguardian.com/australia-news/australia-news",
+            "apiUrl": "https://content.guardianapis.com/australia-news/australia-news",
+            "references": [],
+            "internalName": "Australia (News)"
+          },
+          {
+            "id": "australia-news/queensland",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Queensland",
+            "webUrl": "https://www.theguardian.com/australia-news/queensland",
+            "apiUrl": "https://content.guardianapis.com/australia-news/queensland",
+            "references": [],
+            "description": "Latest news and comment on the Australian state of Queensland",
+            "internalName": "Queensland (news)"
+          },
+          {
+            "id": "media/social-media",
+            "type": "keyword",
+            "sectionId": "media",
+            "sectionName": "Media",
+            "webTitle": "Social media",
+            "webUrl": "https://www.theguardian.com/media/social-media",
+            "apiUrl": "https://content.guardianapis.com/media/social-media",
+            "references": [],
+            "internalName": "Social media"
+          },
+          {
+            "id": "australia-news/health",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Health",
+            "webUrl": "https://www.theguardian.com/australia-news/health",
+            "apiUrl": "https://content.guardianapis.com/australia-news/health",
+            "references": [],
+            "internalName": "Health (Australia)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-6628862a8f0839cf006b1636",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/04/30-06743-FS_MyPlace_ch_300424_1045.mp3",
+                "typeData": {
+                  "source": "guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/04/30-06743-FS_MyPlace_ch_300424_1045.mp3",
+                  "sizeInBytes": "26048727",
+                  "durationMinutes": "18",
+                  "durationSeconds": "5",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "c6f1e510b85a149600f98d8ccac5d4ee33568ab2",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/c6f1e510b85a149600f98d8ccac5d4ee33568ab2/0_2_3000_1800/master/3000.jpg",
+                "typeData": {
+                  "altText": "A dentist inspects a patient's teeth",
+                  "credit": "Photograph: Rui Vieira/PA",
+                  "photographer": "Rui Vieira",
+                  "source": "PA",
+                  "width": "3000",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/c6f1e510b85a149600f98d8ccac5d4ee33568ab2/0_2_3000_1800/master/3000.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "c6f1e510b85a149600f98d8ccac5d4ee33568ab2",
+                  "imageType": "Photograph",
+                  "suppliersReference": "pa-new/HEALTH Dental  06524935.JPG",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/c6f1e510b85a149600f98d8ccac5d4ee33568ab2"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/c6f1e510b85a149600f98d8ccac5d4ee33568ab2/0_2_3000_1800/3000.jpg",
+                "typeData": {
+                  "altText": "A dentist inspects a patient's teeth",
+                  "credit": "Photograph: Rui Vieira/PA",
+                  "photographer": "Rui Vieira",
+                  "source": "PA",
+                  "width": "3000",
+                  "height": "1800",
+                  "secureFile": "https://media.guim.co.uk/c6f1e510b85a149600f98d8ccac5d4ee33568ab2/0_2_3000_1800/3000.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "c6f1e510b85a149600f98d8ccac5d4ee33568ab2",
+                  "imageType": "Photograph",
+                  "suppliersReference": "pa-new/HEALTH Dental  06524935.JPG",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/c6f1e510b85a149600f98d8ccac5d4ee33568ab2"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/c6f1e510b85a149600f98d8ccac5d4ee33568ab2/0_2_3000_1800/500.jpg",
+                "typeData": {
+                  "altText": "A dentist inspects a patient's teeth",
+                  "credit": "Photograph: Rui Vieira/PA",
+                  "photographer": "Rui Vieira",
+                  "source": "PA",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/c6f1e510b85a149600f98d8ccac5d4ee33568ab2/0_2_3000_1800/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "c6f1e510b85a149600f98d8ccac5d4ee33568ab2",
+                  "imageType": "Photograph",
+                  "suppliersReference": "pa-new/HEALTH Dental  06524935.JPG",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/c6f1e510b85a149600f98d8ccac5d4ee33568ab2"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/news",
+        "pillarName": "News"
+      },
+      {
+        "id": "australia-news/audio/2024/apr/29/jess-hill-on-what-it-will-take-to-stop-men-killing-women-full-story-podcast",
+        "type": "audio",
+        "sectionId": "australia-news",
+        "sectionName": "Australia news",
+        "webPublicationDate": "2024-04-29T15:00:21Z",
+        "webTitle": "Jess Hill on what it will take to stop men killing women – podcast",
+        "webUrl": "https://www.theguardian.com/australia-news/audio/2024/apr/29/jess-hill-on-what-it-will-take-to-stop-men-killing-women-full-story-podcast",
+        "apiUrl": "https://content.guardianapis.com/australia-news/audio/2024/apr/29/jess-hill-on-what-it-will-take-to-stop-men-killing-women-full-story-podcast",
+        "fields": {
+          "standfirst": "<p>For many years political leaders have condemned violence against women and expressed platitudes about the need for change. But government policies to reduce gender-based violence have failed and frontline services say they are severely underfunded. Journalist and coercive control educator <strong>Jess Hill</strong> speaks to <strong>Nour Haydar</strong> about the major paradigm shift that governments still need to make</p><ul><li>You can support the Guardian at <a href=\"http://theguardian.com/fullstorysupport\">theguardian.com/fullstorysupport</a></li></ul>",
+          "trailText": "Journalist and coercive control educator <strong>Jess Hill</strong> speaks to <strong>Nour Haydar</strong>",
+          "internalComposerCode": "662f31a98f082fbf29749f44"
+        },
+        "tags": [
+          {
+            "id": "society/women",
+            "type": "keyword",
+            "sectionId": "society",
+            "sectionName": "Society",
+            "webTitle": "Women",
+            "webUrl": "https://www.theguardian.com/society/women",
+            "apiUrl": "https://content.guardianapis.com/society/women",
+            "references": [],
+            "internalName": "Women (Society)"
+          },
+          {
+            "id": "society/domestic-violence",
+            "type": "keyword",
+            "sectionId": "society",
+            "sectionName": "Society",
+            "webTitle": "Domestic violence",
+            "webUrl": "https://www.theguardian.com/society/domestic-violence",
+            "apiUrl": "https://content.guardianapis.com/society/domestic-violence",
+            "references": [],
+            "internalName": "Domestic violence (Society)"
+          },
+          {
+            "id": "australia-news/crime-australia",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Crime - Australia",
+            "webUrl": "https://www.theguardian.com/australia-news/crime-australia",
+            "apiUrl": "https://content.guardianapis.com/australia-news/crime-australia",
+            "references": [],
+            "description": "Latest news on crime in Australia from the Guardian",
+            "internalName": "Crime (Australia)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-662f31a98f082fbf29749f44",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/04/29-41283-FS_JH.mp3",
+                "typeData": {
+                  "source": "guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/04/29-41283-FS_JH.mp3",
+                  "sizeInBytes": "33724456",
+                  "durationMinutes": "23",
+                  "durationSeconds": "25",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "547d903fa0f98d6dd04609d7462aa5b37603fe92",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/547d903fa0f98d6dd04609d7462aa5b37603fe92/0_444_8256_4954/master/8256.jpg",
+                "typeData": {
+                  "altText": "Australian Prime Minister Anthony Albanese attends a rally to a call for action to end violence against women, in Canberra",
+                  "credit": "Photograph: Lukas Coch/AAP",
+                  "photographer": "Lukas Coch",
+                  "source": "AAP",
+                  "width": "8256",
+                  "height": "4954",
+                  "secureFile": "https://media.guim.co.uk/547d903fa0f98d6dd04609d7462aa5b37603fe92/0_444_8256_4954/master/8256.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "547d903fa0f98d6dd04609d7462aa5b37603fe92",
+                  "imageType": "Photograph",
+                  "suppliersReference": "CNB",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/547d903fa0f98d6dd04609d7462aa5b37603fe92"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/547d903fa0f98d6dd04609d7462aa5b37603fe92/0_444_8256_4954/8256.jpg",
+                "typeData": {
+                  "altText": "Australian Prime Minister Anthony Albanese attends a rally to a call for action to end violence against women, in Canberra",
+                  "credit": "Photograph: Lukas Coch/AAP",
+                  "photographer": "Lukas Coch",
+                  "source": "AAP",
+                  "width": "8256",
+                  "height": "4954",
+                  "secureFile": "https://media.guim.co.uk/547d903fa0f98d6dd04609d7462aa5b37603fe92/0_444_8256_4954/8256.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "547d903fa0f98d6dd04609d7462aa5b37603fe92",
+                  "imageType": "Photograph",
+                  "suppliersReference": "CNB",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/547d903fa0f98d6dd04609d7462aa5b37603fe92"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/547d903fa0f98d6dd04609d7462aa5b37603fe92/0_444_8256_4954/500.jpg",
+                "typeData": {
+                  "altText": "Australian Prime Minister Anthony Albanese attends a rally to a call for action to end violence against women, in Canberra",
+                  "credit": "Photograph: Lukas Coch/AAP",
+                  "photographer": "Lukas Coch",
+                  "source": "AAP",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/547d903fa0f98d6dd04609d7462aa5b37603fe92/0_444_8256_4954/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "547d903fa0f98d6dd04609d7462aa5b37603fe92",
+                  "imageType": "Photograph",
+                  "suppliersReference": "CNB",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/547d903fa0f98d6dd04609d7462aa5b37603fe92"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/news",
+        "pillarName": "News"
+      },
+      {
+        "id": "australia-news/audio/2024/apr/29/why-are-police-cracking-down-on-us-campus-protests-full-story-podcast",
+        "type": "audio",
+        "sectionId": "australia-news",
+        "sectionName": "Australia news",
+        "webPublicationDate": "2024-04-28T15:00:08Z",
+        "webTitle": "Why are police cracking down on US campus protests? – podcast",
+        "webUrl": "https://www.theguardian.com/australia-news/audio/2024/apr/29/why-are-police-cracking-down-on-us-campus-protests-full-story-podcast",
+        "apiUrl": "https://content.guardianapis.com/australia-news/audio/2024/apr/29/why-are-police-cracking-down-on-us-campus-protests-full-story-podcast",
+        "fields": {
+          "standfirst": "<p>Police have arrested dozens of pro-Palestinian university students. <strong>Erum Salam</strong> and <strong>Margaret Sullivan</strong> report from New York</p><ul><li>You can support the Guardian at <a href=\"http://theguardian.com/fullstorysupport\">theguardian.com/fullstorysupport</a></li></ul>",
+          "trailText": "Police have arrested dozens of pro-Palestinian university students. <strong>Erum Salam</strong> and <strong>Margaret Sullivan</strong> report from New York",
+          "internalComposerCode": "662b20f38f080a6bbc5902d6"
+        },
+        "tags": [
+          {
+            "id": "us-news/us-universities",
+            "type": "keyword",
+            "sectionId": "us-news",
+            "sectionName": "US news",
+            "webTitle": "US universities",
+            "webUrl": "https://www.theguardian.com/us-news/us-universities",
+            "apiUrl": "https://content.guardianapis.com/us-news/us-universities",
+            "references": [],
+            "internalName": "Universities (US)"
+          },
+          {
+            "id": "world/protest",
+            "type": "keyword",
+            "sectionId": "world",
+            "sectionName": "World news",
+            "webTitle": "Protest",
+            "webUrl": "https://www.theguardian.com/world/protest",
+            "apiUrl": "https://content.guardianapis.com/world/protest",
+            "references": [],
+            "internalName": "Protest (News)"
+          },
+          {
+            "id": "us-news/us-news",
+            "type": "keyword",
+            "sectionId": "us-news",
+            "sectionName": "US news",
+            "webTitle": "US news",
+            "webUrl": "https://www.theguardian.com/us-news/us-news",
+            "apiUrl": "https://content.guardianapis.com/us-news/us-news",
+            "references": [],
+            "internalName": "US news"
+          },
+          {
+            "id": "us-news/us-campus-protests",
+            "type": "keyword",
+            "sectionId": "us-news",
+            "sectionName": "US news",
+            "webTitle": "US campus protests",
+            "webUrl": "https://www.theguardian.com/us-news/us-campus-protests",
+            "apiUrl": "https://content.guardianapis.com/us-news/us-campus-protests",
+            "references": [],
+            "internalName": "US campus protests (2024)"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-662b20f38f080a6bbc5902d6",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/04/26-13250-Tif_FS_USUniversities_129.mp3",
+                "typeData": {
+                  "source": "Guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/04/26-13250-Tif_FS_USUniversities_129.mp3",
+                  "sizeInBytes": "42046324",
+                  "durationMinutes": "29",
+                  "durationSeconds": "11",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "4cf41dc3d5cffc62bb98024dbe0ad19a5fe62e91",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/4cf41dc3d5cffc62bb98024dbe0ad19a5fe62e91/0_274_5568_3341/master/5568.jpg",
+                "typeData": {
+                  "altText": "Columbia Univeristy Pro-Palestinian encampment endures, New York",
+                  "credit": "Photograph: Andrea Renault/ZUMA Press Wire/REX/Shutterstock",
+                  "photographer": "Andrea Renault",
+                  "source": "ZUMA Press Wire/REX/Shutterstock",
+                  "width": "5568",
+                  "height": "3341",
+                  "secureFile": "https://media.guim.co.uk/4cf41dc3d5cffc62bb98024dbe0ad19a5fe62e91/0_274_5568_3341/master/5568.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "4cf41dc3d5cffc62bb98024dbe0ad19a5fe62e91",
+                  "imageType": "Photograph",
+                  "suppliersReference": "14449408ae",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/4cf41dc3d5cffc62bb98024dbe0ad19a5fe62e91"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/4cf41dc3d5cffc62bb98024dbe0ad19a5fe62e91/0_274_5568_3341/5568.jpg",
+                "typeData": {
+                  "altText": "Columbia Univeristy Pro-Palestinian encampment endures, New York",
+                  "credit": "Photograph: Andrea Renault/ZUMA Press Wire/REX/Shutterstock",
+                  "photographer": "Andrea Renault",
+                  "source": "ZUMA Press Wire/REX/Shutterstock",
+                  "width": "5568",
+                  "height": "3341",
+                  "secureFile": "https://media.guim.co.uk/4cf41dc3d5cffc62bb98024dbe0ad19a5fe62e91/0_274_5568_3341/5568.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "4cf41dc3d5cffc62bb98024dbe0ad19a5fe62e91",
+                  "imageType": "Photograph",
+                  "suppliersReference": "14449408ae",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/4cf41dc3d5cffc62bb98024dbe0ad19a5fe62e91"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/4cf41dc3d5cffc62bb98024dbe0ad19a5fe62e91/0_274_5568_3341/500.jpg",
+                "typeData": {
+                  "altText": "Columbia Univeristy Pro-Palestinian encampment endures, New York",
+                  "credit": "Photograph: Andrea Renault/ZUMA Press Wire/REX/Shutterstock",
+                  "photographer": "Andrea Renault",
+                  "source": "ZUMA Press Wire/REX/Shutterstock",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/4cf41dc3d5cffc62bb98024dbe0ad19a5fe62e91/0_274_5568_3341/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "4cf41dc3d5cffc62bb98024dbe0ad19a5fe62e91",
+                  "imageType": "Photograph",
+                  "suppliersReference": "14449408ae",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/4cf41dc3d5cffc62bb98024dbe0ad19a5fe62e91"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/news",
+        "pillarName": "News"
+      },
+      {
+        "id": "australia-news/audio/2024/apr/26/newsroom-edition-musk-meta-and-tiktok-can-governments-control-big-tech-full-story-podcast",
+        "type": "audio",
+        "sectionId": "australia-news",
+        "sectionName": "Australia news",
+        "webPublicationDate": "2024-04-25T15:00:29Z",
+        "webTitle": "Newsroom edition: can governments control big tech? – podcast",
+        "webUrl": "https://www.theguardian.com/australia-news/audio/2024/apr/26/newsroom-edition-musk-meta-and-tiktok-can-governments-control-big-tech-full-story-podcast",
+        "apiUrl": "https://content.guardianapis.com/australia-news/audio/2024/apr/26/newsroom-edition-musk-meta-and-tiktok-can-governments-control-big-tech-full-story-podcast",
+        "fields": {
+          "standfirst": "<p>As the Australian government faces off with Elon Musk and his social media platform X, a global battle to better regulate the world’s biggest social platforms is kicking off.<br><br><strong>Nour Haydar</strong> speaks to editor-in-chief <strong>Lenore Taylor</strong> and deputy editor <strong>Patrick Keneally </strong>about the trouble with regulating global social media giants, and how it will affect the future of journalism</p>",
+          "trailText": "<strong>Nour Haydar</strong> speaks to editor-in-chief <strong>Lenore Taylor</strong> and deputy editor <strong>Patrick Keneally </strong>about the trouble with regulating global social media giants, and how it’ll affect the future of journalism",
+          "internalComposerCode": "6629ef0c8f0881afefd55e74"
+        },
+        "tags": [
+          {
+            "id": "media/social-media",
+            "type": "keyword",
+            "sectionId": "media",
+            "sectionName": "Media",
+            "webTitle": "Social media",
+            "webUrl": "https://www.theguardian.com/media/social-media",
+            "apiUrl": "https://content.guardianapis.com/media/social-media",
+            "references": [],
+            "internalName": "Social media"
+          },
+          {
+            "id": "technology/elon-musk",
+            "type": "keyword",
+            "sectionId": "technology",
+            "sectionName": "Technology",
+            "webTitle": "Elon Musk",
+            "webUrl": "https://www.theguardian.com/technology/elon-musk",
+            "apiUrl": "https://content.guardianapis.com/technology/elon-musk",
+            "references": [],
+            "internalName": "Elon Musk"
+          },
+          {
+            "id": "technology/meta",
+            "type": "keyword",
+            "sectionId": "technology",
+            "sectionName": "Technology",
+            "webTitle": "Meta",
+            "webUrl": "https://www.theguardian.com/technology/meta",
+            "apiUrl": "https://content.guardianapis.com/technology/meta",
+            "references": [],
+            "internalName": "Meta"
+          },
+          {
+            "id": "technology/twitter",
+            "type": "keyword",
+            "sectionId": "technology",
+            "sectionName": "Technology",
+            "webTitle": "X",
+            "webUrl": "https://www.theguardian.com/technology/twitter",
+            "apiUrl": "https://content.guardianapis.com/technology/twitter",
+            "references": [],
+            "description": "<p><br></p>",
+            "internalName": "Twitter X Corp (Technology)"
+          },
+          {
+            "id": "technology/tiktok",
+            "type": "keyword",
+            "sectionId": "technology",
+            "sectionName": "Technology",
+            "webTitle": "TikTok",
+            "webUrl": "https://www.theguardian.com/technology/tiktok",
+            "apiUrl": "https://content.guardianapis.com/technology/tiktok",
+            "references": [],
+            "internalName": "TikTok"
+          },
+          {
+            "id": "australia-news/australian-politics",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Australian politics",
+            "webUrl": "https://www.theguardian.com/australia-news/australian-politics",
+            "apiUrl": "https://content.guardianapis.com/australia-news/australian-politics",
+            "references": [],
+            "internalName": "Australian politics"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-6629ef0c8f0881afefd55e74",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/04/25-29028-FS_FS_Platforms_ch_250424_1725.mp3",
+                "typeData": {
+                  "source": "guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/04/25-29028-FS_FS_Platforms_ch_250424_1725.mp3",
+                  "sizeInBytes": "36424569",
+                  "durationMinutes": "25",
+                  "durationSeconds": "17",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "7ea75de00d3cc53e25ad09cca23782b28787017e",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/7ea75de00d3cc53e25ad09cca23782b28787017e/0_156_4500_2700/master/4500.jpg",
+                "typeData": {
+                  "altText": "A person looks at an iPhone screen showing various social media apps including TikTok, Facebook and X",
+                  "credit": "Photograph: Matt Cardy/Getty Images",
+                  "photographer": "Matt Cardy",
+                  "source": "Getty Images",
+                  "width": "4500",
+                  "height": "2700",
+                  "secureFile": "https://media.guim.co.uk/7ea75de00d3cc53e25ad09cca23782b28787017e/0_156_4500_2700/master/4500.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "7ea75de00d3cc53e25ad09cca23782b28787017e",
+                  "imageType": "Photograph",
+                  "suppliersReference": "1892966240",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/7ea75de00d3cc53e25ad09cca23782b28787017e"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/7ea75de00d3cc53e25ad09cca23782b28787017e/0_156_4500_2700/4500.jpg",
+                "typeData": {
+                  "altText": "A person looks at an iPhone screen showing various social media apps including TikTok, Facebook and X",
+                  "credit": "Photograph: Matt Cardy/Getty Images",
+                  "photographer": "Matt Cardy",
+                  "source": "Getty Images",
+                  "width": "4500",
+                  "height": "2700",
+                  "secureFile": "https://media.guim.co.uk/7ea75de00d3cc53e25ad09cca23782b28787017e/0_156_4500_2700/4500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "7ea75de00d3cc53e25ad09cca23782b28787017e",
+                  "imageType": "Photograph",
+                  "suppliersReference": "1892966240",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/7ea75de00d3cc53e25ad09cca23782b28787017e"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/7ea75de00d3cc53e25ad09cca23782b28787017e/0_156_4500_2700/500.jpg",
+                "typeData": {
+                  "altText": "A person looks at an iPhone screen showing various social media apps including TikTok, Facebook and X",
+                  "credit": "Photograph: Matt Cardy/Getty Images",
+                  "photographer": "Matt Cardy",
+                  "source": "Getty Images",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/7ea75de00d3cc53e25ad09cca23782b28787017e/0_156_4500_2700/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "7ea75de00d3cc53e25ad09cca23782b28787017e",
+                  "imageType": "Photograph",
+                  "suppliersReference": "1892966240",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/7ea75de00d3cc53e25ad09cca23782b28787017e"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/news",
+        "pillarName": "News"
+      },
+      {
+        "id": "australia-news/audio/2024/apr/24/is-elon-musk-above-australian-law-full-story-podcast",
+        "type": "audio",
+        "sectionId": "australia-news",
+        "sectionName": "Australia news",
+        "webPublicationDate": "2024-04-24T15:00:14Z",
+        "webTitle": "Is Elon Musk above Australian law? – podcast",
+        "webUrl": "https://www.theguardian.com/australia-news/audio/2024/apr/24/is-elon-musk-above-australian-law-full-story-podcast",
+        "apiUrl": "https://content.guardianapis.com/australia-news/audio/2024/apr/24/is-elon-musk-above-australian-law-full-story-podcast",
+        "fields": {
+          "standfirst": "<p>Anthony Albanese has labelled X’s owner, Elon Musk, an “arrogant billionaire who thinks he is above the law” as the rift deepens between Australia and the tech platform over the removal of videos of a violent stabbing in a Sydney church.</p><p>Reporter <strong>Josh Taylor</strong> tells <strong>Jane Lee</strong> how this stoush started, and if it’s possible to stop the spread of violent material and misinformation online</p><ul><li>You can support the Guardian at <a href=\"http://theguardian.com/fullstorysupport\">theguardian.com/fullstorysupport</a></li></ul>",
+          "trailText": "Reporter <strong>Josh Taylor</strong> tells <strong>Jane Lee</strong> how the stoush between Elon Musk’s X and Australia started, and if it’s possible to stop the spread of violent material and misinformation online",
+          "internalComposerCode": "66289cdf8f0839cf006b16c1"
+        },
+        "tags": [
+          {
+            "id": "technology/elon-musk",
+            "type": "keyword",
+            "sectionId": "technology",
+            "sectionName": "Technology",
+            "webTitle": "Elon Musk",
+            "webUrl": "https://www.theguardian.com/technology/elon-musk",
+            "apiUrl": "https://content.guardianapis.com/technology/elon-musk",
+            "references": [],
+            "internalName": "Elon Musk"
+          },
+          {
+            "id": "australia-news/anthony-albanese",
+            "type": "keyword",
+            "sectionId": "australia-news",
+            "sectionName": "Australia news",
+            "webTitle": "Anthony Albanese",
+            "webUrl": "https://www.theguardian.com/australia-news/anthony-albanese",
+            "apiUrl": "https://content.guardianapis.com/australia-news/anthony-albanese",
+            "references": [],
+            "internalName": "Anthony Albanese (Australian politics)"
+          },
+          {
+            "id": "media/social-media",
+            "type": "keyword",
+            "sectionId": "media",
+            "sectionName": "Media",
+            "webTitle": "Social media",
+            "webUrl": "https://www.theguardian.com/media/social-media",
+            "apiUrl": "https://content.guardianapis.com/media/social-media",
+            "references": [],
+            "internalName": "Social media"
+          },
+          {
+            "id": "technology/twitter",
+            "type": "keyword",
+            "sectionId": "technology",
+            "sectionName": "Technology",
+            "webTitle": "X",
+            "webUrl": "https://www.theguardian.com/technology/twitter",
+            "apiUrl": "https://content.guardianapis.com/technology/twitter",
+            "references": [],
+            "description": "<p><br></p>",
+            "internalName": "Twitter X Corp (Technology)"
+          },
+          {
+            "id": "media/media",
+            "type": "keyword",
+            "sectionId": "media",
+            "sectionName": "Media",
+            "webTitle": "Media",
+            "webUrl": "https://www.theguardian.com/media/media",
+            "apiUrl": "https://content.guardianapis.com/media/media",
+            "references": [],
+            "internalName": "Media"
+          },
+          {
+            "id": "technology/technology",
+            "type": "keyword",
+            "sectionId": "technology",
+            "sectionName": "Technology",
+            "webTitle": "Technology",
+            "webUrl": "https://www.theguardian.com/technology/technology",
+            "apiUrl": "https://content.guardianapis.com/technology/technology",
+            "references": [],
+            "internalName": "Technology"
+          }
+        ],
+        "elements": [
+          {
+            "id": "gu-audio-66289cdf8f0839cf006b16c1",
+            "relation": "main",
+            "type": "audio",
+            "assets": [
+              {
+                "type": "audio",
+                "mimeType": "audio/mpeg",
+                "file": "https://audio.guim.co.uk/2024/04/24-29461-FullStory_Musk_JM_8_2024-04-24_17_15.mp3",
+                "typeData": {
+                  "source": "guardian",
+                  "secureFile": "https://audio.guim.co.uk/2024/04/24-29461-FullStory_Musk_JM_8_2024-04-24_17_15.mp3",
+                  "sizeInBytes": "28884925",
+                  "durationMinutes": "20",
+                  "durationSeconds": "3",
+                  "embedType": "audio",
+                  "clean": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "a4f69a74eb31bc50a419ca2983527fd93e095e20",
+            "relation": "thumbnail",
+            "type": "image",
+            "assets": [
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/a4f69a74eb31bc50a419ca2983527fd93e095e20/0_0_3932_2358/master/3932.jpg",
+                "typeData": {
+                  "altText": "Elon Musk",
+                  "credit": "Photograph: Peter Parks/AFP/Getty Images",
+                  "photographer": "Peter Parks",
+                  "source": "AFP/Getty Images",
+                  "width": "3932",
+                  "height": "2358",
+                  "secureFile": "https://media.guim.co.uk/a4f69a74eb31bc50a419ca2983527fd93e095e20/0_0_3932_2358/master/3932.jpg",
+                  "isMaster": "true",
+                  "displayCredit": "true",
+                  "mediaId": "a4f69a74eb31bc50a419ca2983527fd93e095e20",
+                  "imageType": "Photograph",
+                  "suppliersReference": "AFP_1A7945",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/a4f69a74eb31bc50a419ca2983527fd93e095e20"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/a4f69a74eb31bc50a419ca2983527fd93e095e20/0_0_3932_2358/3932.jpg",
+                "typeData": {
+                  "altText": "Elon Musk",
+                  "credit": "Photograph: Peter Parks/AFP/Getty Images",
+                  "photographer": "Peter Parks",
+                  "source": "AFP/Getty Images",
+                  "width": "3932",
+                  "height": "2358",
+                  "secureFile": "https://media.guim.co.uk/a4f69a74eb31bc50a419ca2983527fd93e095e20/0_0_3932_2358/3932.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "a4f69a74eb31bc50a419ca2983527fd93e095e20",
+                  "imageType": "Photograph",
+                  "suppliersReference": "AFP_1A7945",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/a4f69a74eb31bc50a419ca2983527fd93e095e20"
+                }
+              },
+              {
+                "type": "image",
+                "file": "https://media.guim.co.uk/a4f69a74eb31bc50a419ca2983527fd93e095e20/0_0_3932_2358/500.jpg",
+                "typeData": {
+                  "altText": "Elon Musk",
+                  "credit": "Photograph: Peter Parks/AFP/Getty Images",
+                  "photographer": "Peter Parks",
+                  "source": "AFP/Getty Images",
+                  "width": "500",
+                  "height": "300",
+                  "secureFile": "https://media.guim.co.uk/a4f69a74eb31bc50a419ca2983527fd93e095e20/0_0_3932_2358/500.jpg",
+                  "displayCredit": "true",
+                  "mediaId": "a4f69a74eb31bc50a419ca2983527fd93e095e20",
+                  "imageType": "Photograph",
+                  "suppliersReference": "AFP_1A7945",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/a4f69a74eb31bc50a419ca2983527fd93e095e20"
+                }
+              }
+            ]
+          }
+        ],
+        "references": [],
+        "isHosted": false,
+        "pillarId": "pillar/news",
+        "pillarName": "News"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What does this change?

For the ~AU full-story~ Grace Dent Comfort Eating podcast we want to use episodic artwork if possible. This tests the water in that area.

## How to test

Locally you can export the necessary env vars (see the README) and run it. It'll generate the <itunes:image> elements for appropriate podcast's episodes only. The links won't actually work unless you export the correct salt. The salt also needs to be added to our configuration for access by `SecretKeeper`.

## How can we measure success?

If we see per-episode images... success!

## Have we considered potential risks?

* Currently there are no coded protections against older series episodes - we may need a date-based gate to enable this in production.
* We exclude master assets from being considered for selection - this may or may not have to remain
* We don't specify an upper- or lower-bound size limit on the assets we do select - this may have to be added
* Regardless of which image we select we'll always ask Fastly to make a 3000px square crop - this may have to be adjusted according to the size of the image asset we select

## Images

TBA

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-  [x] N/A
