### PR TITLE
Remove empty local config handler, should work same as apiKey

### DIFF
--- a/app/com/gu/itunes/SecretKeeper.scala
+++ b/app/com/gu/itunes/SecretKeeper.scala
@@ -86,9 +86,6 @@ object SecretKeeper {
     case fromConfig @ Some(sigSalt) if sigSalt != "" =>
       logger.info("Loaded the fastly image resizer signature salt from configuration")
       fromConfig
-    case fromConfig @ Some(sigSalt) if sigSalt == "" =>
-      logger.warn("Loaded the fastly image resizer signature salt from configuration but it was an empty string")
-      None
     case _ =>
       loadFastlySignatureSaltFromSecretsManager()
   }


### PR DESCRIPTION
Fix for configuration snafu in https://github.com/guardian/itunes-rss/pull/157

## What does this change?

We shouldn't use config file fastly salt value if empty in PROD as it stops us from getting the real value from secrets manager 🙄 

## How to test

Tests still complete locally. Will need to check logs after deployment.

## How can we measure success?

Before
`Loaded the fastly image resizer signature salt from configuration but it was an empty string`

Expected
`Loading <salt secret name> key from secrets manager at /<path-to-the-secret>`

## Have we considered potential risks?

Now that https://github.com/guardian/itunes-rss/pull/157 is in production, not fixing this in time will mean the launch episode of the new series is missed tomorrow.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A

