### PR TITLE
Add href attribute to episode image tag

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -267,7 +267,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
       <itunes:author>{ iTunesRssFeed.author }</itunes:author>
       {
         episodeImage match {
-          case Some(image) => <itunes:image>{ image }</itunes:image>
+          case Some(image) => <itunes:image href={ image }/>
           case None =>
         }
       }

--- a/test/com/gu/itunes/ItunesRssItemSpec.scala
+++ b/test/com/gu/itunes/ItunesRssItemSpec.scala
@@ -166,7 +166,7 @@ class ItunesRssItemSpec extends AnyFlatSpec with ItunesTestData with Matchers wi
     // now check our image exists
     val itunesImages = (rssItemWithEpisodicImage \\ "image")
     itunesImages.size shouldBe (1)
-    val expectedImage = "<itunes:image>https://i.guim.co.uk/img/media/39f24967bf11d6a8298201d29e7f7a3b7e0517b8/0_0_2999_1800/2999.jpg?width=3000&amp;height=3000&amp;quality=75&amp;fit=crop&amp;s=c14d895fa1e69eeff7948fe06f7c4c01</itunes:image>"
+    val expectedImage = """<itunes:image href="https://i.guim.co.uk/img/media/39f24967bf11d6a8298201d29e7f7a3b7e0517b8/0_0_2999_1800/2999.jpg?width=3000&amp;height=3000&amp;quality=75&amp;fit=crop&amp;s=c14d895fa1e69eeff7948fe06f7c4c01"/>"""
     itunesImages.head.toString() shouldBe (expectedImage)
   }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

I got the format of the `<itunes:image>` tag wrong in https://github.com/guardian/itunes-rss/pull/157 - it should have had an `href=` string attribute instead of carrying the link to the image within the tag.

## How to test

Have re-tested locally and updated the unit test so we can be pretty sure it's in the correct format now.

## How can we measure success?

If we can see the artwork on the podcast - success!

## Have we considered potential risks?

Minimal risks here. The image is already in the feed and being ignored. Changing the format should make it work.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A
