### PR TITLE
Change link injected for footballweekly tag to euro-support

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -81,7 +81,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
             ""
         } else if (tagId == "football/series/footballweekly") {
           if (lastModified.isAfter(footballWeekly))
-            """. Help support our independent journalism at <a href="https://www.theguardian.com/footballweeklypod">theguardian.com/footballweeklypod</a>"""
+            """. Help support our independent journalism at <a href="https://www.theguardian.com/euro-support">theguardian.com/euro-support</a>"""
           else ""
         } else {
           ""


### PR DESCRIPTION
## What does this change?

Change link injected for the `football/series/footballweekly` tag to `/euro-support`.

Editorial would like this to run until the 25th of July, after which we can revert.


