### PR TITLE
Bump most dependencies and override the heck out of jackson

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,19 +11,19 @@ val root = Project("podcasts-rss", file("."))
   .enablePlugins(PlayScala, JavaServerAppPackaging, SystemdPlugin)
   .settings(
     libraryDependencies ++= Seq(
-      "org.jsoup" % "jsoup" % "1.17.2",
-      "com.gu" %% "content-api-client" % "26.0.0",
+      "org.jsoup" % "jsoup" % "1.18.1",
+      "com.gu" %% "content-api-client" % "31.0.3",
       "com.squareup.okhttp3" % "okhttp" % "4.12.0", // SNYK-JAVA-ORGJETBRAINSKOTLIN-2393744, SNYK-JAVA-COMSQUAREUPOKIO-5820002
       "software.amazon.awssdk" % "secretsmanager" % "2.25.32", // SNYK-JAVA-IONETTY-1042268
-      "org.scalactic" %% "scalactic" % "3.2.18",
-      "org.scalatest" %% "scalatest" % "3.2.18" % "test",
+      "org.scalactic" %% "scalactic" % "3.2.19",
+      "org.scalatest" %% "scalatest" % "3.2.19" % "test",
       "net.logstash.logback" % "logstash-logback-encoder" % "7.4",
-      "com.gu" %% "content-api-models-json" % "23.0.0" % "test", // keeping in line with imports from content-api-client
+      "com.gu" %% "content-api-models-json" % "25.0.0" % "test", // keeping in line with imports from content-api-client
       "com.gu" %% "simple-configuration-core" % "2.0.0",
       "com.gu.play-secret-rotation" %% "play-v30" % "8.2.1",
       "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "8.2.1",
       //AWS SDK v2 clients
-      "software.amazon.awssdk" % "url-connection-client" % "2.25.32", //only used at startup. For operations we use akka http client
+      "software.amazon.awssdk" % "url-connection-client" % "2.26.22", //only used at startup. For operations we use akka http client
       "joda-time" % "joda-time" % "2.12.7"
     ),
     maintainer := "Guardian Content Platforms <content-platforms.dev@theguardian.com>",
@@ -38,8 +38,15 @@ val root = Project("podcasts-rss", file("."))
 Universal / packageName := normalizedName.value
 
 dependencyOverrides ++=Seq(
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.3",
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.14.3"
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.17.1",
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % "2.17.2",
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.17.2",
+  "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % "2.17.2",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.17.2",
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.17.2",
+  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.17.2",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.17.0",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.17.2"
 )
 
 excludeDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.5")
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
 //otherwise the build fails because of scala-compiler wanting a newer version of scala-xml
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always


### PR DESCRIPTION
## What does this change?

Updates most dependencies

## How to test

Local tests passed. Local side-by-side comparison with PROD looked identical.

## How can we measure success?

Updated dependencies and operational service? Success!

## Have we considered potential risks?

There could be untested paths that haven't tickled the updated code. But this is always true - we'll rollback or fix forward depending on severity if we find anything like that.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A
