### PR TITLE
Improve test output locally

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,11 @@ val root = Project("podcasts-rss", file("."))
     daemonUser := "content-api",
     daemonGroup := "content-api",
     linuxPackageMappings += packageTemplateMapping(s"/var/run/${name.value}")() withUser (daemonUser.value) withGroup (daemonGroup.value),
-    Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", sys.env.getOrElse("SBT_JUNIT_OUTPUT", "junit"))
+    Test / testOptions += Tests.Argument(
+      TestFrameworks.ScalaTest,
+      "-u", sys.env.getOrElse("SBT_JUNIT_OUTPUT", "junit"),
+      "-o"
+    )
 )
 
 Universal / packageName := normalizedName.value

--- a/test/resources/logback-test.xml
+++ b/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date %-5level %logger - %msg%n%xException{30}</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="play" level="OFF" />
+    <logger name="com.gu.crier" level="OFF"/>
+
+    <root level="OFF">
+       <appender-ref ref="console"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Here are a couple of small improvements to the test output when run locally: see the individual commit messages for more details.

This PR is inspired by the changes @fredex42 and I made to crier in https://github.com/guardian/crier/pull/174 (specifically commit https://github.com/guardian/crier/commit/59206fae5b65b5ece9b83df65f1b3bcba1637155).