### PR TITLE
Enable episodic artwork for Full Story podcast

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -13,8 +13,10 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
   private val standfirstOrTrail = podcast.fields.flatMap(_.standfirst) orElse trailText
 
   private def isValidForEpisodicArtwork(podcast: Content): Boolean = {
-    tagId == "lifeandstyle/series/comforteatingwithgracedent" &&
-      podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2024, 6, 11, 0, 0).getMillis)
+    (tagId == "lifeandstyle/series/comforteatingwithgracedent" &&
+      podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2024, 6, 11, 0, 0).getMillis)) ||
+      (tagId == "australia-news/series/full-story" &&
+        podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2024, 10, 7, 0, 0).getMillis))
   }
 
   def toXml: Node = {

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -16,7 +16,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
     (tagId == "lifeandstyle/series/comforteatingwithgracedent" &&
       podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2024, 6, 11, 0, 0).getMillis)) ||
       (tagId == "australia-news/series/full-story" &&
-        podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2024, 10, 7, 0, 0).getMillis))
+        podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2024, 10, 8, 0, 0).getMillis))
   }
 
   def toXml: Node = {


### PR DESCRIPTION
## What does this change?

Adds the full story series tag and a start date of ~today (Monday October 7th)~ Tuesday October 8th for the first inclusion of the episodic artwork for that series.

## How to test

Tested locally using Sunday October 6th as the activation date because Monday's edition wasn't available at the time.

Before:
```
<item>
<title>How England’s far-right riots erupted</title>
<itunes:title>How England’s far-right riots erupted</itunes:title>
<description>When racist chants rang out and homes, businesses and hotels housing asylum seekers were attacked, for a week in July and August English towns and cities seemed on the brink of chaos. This outbreak followed the deaths of three young children at a Taylor Swift-themed dance class. Josh Halliday reports on what we know so far about the people at the centre of the violence</description>
<enclosure url="REDACTED" length="43093712" type="audio/mpeg"/>
<pubDate>Sun, 06 Oct 2024 14:00:09 GMT</pubDate>
<guid isPermaLink="false">66ff5eb38f0818b7c81cc212</guid>
<itunes:duration>00:29:55</itunes:duration>
<itunes:author>The Guardian</itunes:author>
<itunes:explicit>yes</itunes:explicit>
<itunes:keywords>Protest, Race, Far right</itunes:keywords>
<itunes:subtitle>Josh Halliday reports on what we know so far about the people at the centre of violent protests, which followed the deaths of three young children at a Taylor Swift-themed dance class</itunes:subtitle>
<itunes:summary>When racist chants rang out and homes, businesses and hotels housing asylum seekers were attacked, for a week in July and August English towns and cities seemed on the brink of chaos. This outbreak followed the deaths of three young children at a Taylor Swift-themed dance class. Josh Halliday reports on what we know so far about the people at the centre of the violence</itunes:summary>
</item>
```

After:
```
<item>
<title>How England’s far-right riots erupted</title>
<itunes:title>How England’s far-right riots erupted</itunes:title>
<description>When racist chants rang out and homes, businesses and hotels housing asylum seekers were attacked, for a week in July and August English towns and cities seemed on the brink of chaos. This outbreak followed the deaths of three young children at a Taylor Swift-themed dance class. Josh Halliday reports on what we know so far about the people at the centre of the violence</description>
<enclosure url="REDACTED" length="43093712" type="audio/mpeg"/>
<pubDate>Sun, 06 Oct 2024 14:00:09 GMT</pubDate>
<guid isPermaLink="false">66ff5eb38f0818b7c81cc212</guid>
<itunes:duration>00:29:55</itunes:duration>
<itunes:author>The Guardian</itunes:author>
<itunes:image href="REDACTED"/>
<itunes:explicit>yes</itunes:explicit>
<itunes:keywords>Protest, Race, Far right</itunes:keywords>
<itunes:subtitle>Josh Halliday reports on what we know so far about the people at the centre of violent protests, which followed the deaths of three young children at a Taylor Swift-themed dance class</itunes:subtitle>
<itunes:summary>When racist chants rang out and homes, businesses and hotels housing asylum seekers were attacked, for a week in July and August English towns and cities seemed on the brink of chaos. This outbreak followed the deaths of three young children at a Taylor Swift-themed dance class. Josh Halliday reports on what we know so far about the people at the centre of the violence</itunes:summary>
</item>
```
Note the appearance of the `<itunes:image...` element.

Refer to the Trello card for the redacted values.
 
## How can we measure success?

If the artwork shows up when and where it's supposed to, success!

## Have we considered potential risks?

There are known caveats around the preparation of suitable templates for these images and the worst case is that if done incorrectly, we may get a less than perfect crop.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A
