### PR TITLE
Add new guardian australia podcast series tag

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -16,7 +16,9 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
     (tagId == "lifeandstyle/series/comforteatingwithgracedent" &&
       podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2024, 6, 11, 0, 0).getMillis)) ||
       (tagId == "australia-news/series/full-story" &&
-        podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2024, 10, 8, 0, 0).getMillis))
+        podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2024, 10, 8, 0, 0).getMillis)) ||
+        (tagId == "news/series/guardian-australia-podcast-series" &&
+          podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2022, 10, 1, 0, 0).getMillis))
   }
 
   def toXml: Node = {
@@ -181,7 +183,12 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
         AcastLaunchGroup(new DateTime(2024, 2, 15, 0, 0), Seq(
           "technology/series/blackbox")),
         AcastLaunchGroup(new DateTime(2024, 4, 11, 0, 0), Seq(
-          "australia-news/series/who-screwed-millennials")))
+          "australia-news/series/who-screwed-millennials")),
+        // Yes, the launch date for the guardian-australia-podcast-series is correct. This is a new series tag for
+        // pre-existing episodes that have been re-invigorated by the addition of episodic artwork, but it won't be
+        // re-published. The oldest piece is expected to be from October 2022.
+        AcastLaunchGroup(new DateTime(2022, 10, 1, 0, 0), Seq(
+          "news/series/guardian-australia-podcast-series")))
       val useAcastProxy = !adFree && acastPodcasts.find(_.tagIds.contains(tagId)).exists(p => lastModified.isAfter(p.launchDate))
       if (useAcastProxy) "https://flex.acast.com/" + url.replace("https://", "") else url
     }


### PR DESCRIPTION
## What does this change?

We're setting up for a new tag created to help Australia resurface some past episodes but now with episodic artwork.

## How to test

Once deployed we can query for the new tag and see the data that comes back. It may be largely empty until some episodes have been appropriately tagged.

## How can we measure success?

If the "new" series has episodes with the new artwork, we're good.

## Have we considered potential risks?

This isn't breaking new ground so should be pretty risk-free. No platforms are currently aware of this new series so they won't come asking for it until we tell them about it anyway.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A

