### PR TITLE
Preserve links in rssItem descriptions

### DIFF
--- a/app/com/gu/itunes/Filtering.scala
+++ b/app/com/gu/itunes/Filtering.scala
@@ -5,19 +5,26 @@ import org.jsoup.safety.Safelist
 
 object Filtering {
 
-  val whitelist = Safelist.simpleText().addTags("a")
+  private val defaultSafeList = Safelist.simpleText().addTags("a")
 
-  def standfirst(input: String): String = filter(input)
+  def standfirst(input: String, asHtml: Boolean): String = filter(input, asHtml) // standFirst asHtml preserves links etc
 
-  def description(input: String): String = filter(input)
+  def description(input: String, asHtml: Boolean): String = filter(input, asHtml) // description should not contain html
 
-  private[this] def filter(input: String): String = {
+  private[this] def filter(input: String, asHtml: Boolean): String = {
 
     val doc = Jsoup.parse(input)
     doc.select("br").remove
 
-    val cleaned = Jsoup.clean(doc.outerHtml(), whitelist)
-    Jsoup.parse(cleaned).text()
+    val safeList = if (asHtml) defaultSafeList.addAttributes("a", "href") else defaultSafeList
+
+    val cleaned = Jsoup.clean(doc.outerHtml(), safeList)
+    if (asHtml) {
+      Jsoup.parse(cleaned).body().html()
+    } else {
+      Jsoup.parse(cleaned).text()
+    }
+
   }
 
 }

--- a/app/com/gu/itunes/Filtering.scala
+++ b/app/com/gu/itunes/Filtering.scala
@@ -5,22 +5,27 @@ import org.jsoup.safety.Safelist
 
 object Filtering {
 
-  private val defaultSafeList = Safelist.simpleText().addTags("a")
+  def standfirst(input: String, preserveHtml: Boolean): String = filter(input, preserveHtml) // standFirst can support html tags
 
-  def standfirst(input: String, asHtml: Boolean): String = filter(input, asHtml) // standFirst asHtml preserves links etc
+  def description(input: String): String = filter(input, preserveHtml = false) // description should not contain html tags
 
-  def description(input: String, asHtml: Boolean): String = filter(input, asHtml) // description should not contain html
-
-  private[this] def filter(input: String, asHtml: Boolean): String = {
+  private[this] def filter(input: String, preserveHtml: Boolean): String = {
 
     val doc = Jsoup.parse(input)
     doc.select("br").remove
 
-    val safeList = if (asHtml) defaultSafeList.addAttributes("a", "href") else defaultSafeList
+    val safeList = if (preserveHtml) {
+      Safelist.simpleText()
+        .addAttributes("a", "href")
+        .addEnforcedAttribute("a", "rel", "nofollow")
+    } else {
+      Safelist.simpleText()
+    }
 
     val cleaned = Jsoup.clean(doc.outerHtml(), safeList)
-    if (asHtml) {
-      Jsoup.parse(cleaned).body().html()
+
+    if (preserveHtml) {
+      Jsoup.parse(cleaned).body.html()
     } else {
       Jsoup.parse(cleaned).text()
     }

--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -51,7 +51,7 @@ object iTunesRssFeed {
 
   def toXml(tag: Tag, contents: List[Content], adFree: Boolean, imageResizerSalt: Option[String]): Node Or Failed = {
 
-    val description = Filtering.description(tag.description.getOrElse(""), asHtml = false)
+    val description = Filtering.description(tag.description.getOrElse(""))
 
     tag.podcast match {
       case Some(podcast) => Good {

--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -51,7 +51,7 @@ object iTunesRssFeed {
 
   def toXml(tag: Tag, contents: List[Content], adFree: Boolean, imageResizerSalt: Option[String]): Node Or Failed = {
 
-    val description = Filtering.description(tag.description.getOrElse(""))
+    val description = Filtering.description(tag.description.getOrElse(""), asHtml = false)
 
     tag.podcast match {
       case Some(podcast) => Good {

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -193,7 +193,13 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
       if (useAcastProxy) "https://flex.acast.com/" + url.replace("https://", "") else url
     }
 
-    val description = Filtering.standfirst(standfirstOrTrail.getOrElse(""), asHtml = true) + membershipCta
+    // enabling html in descriptions is a bit of an unknown so we'll restrict the potential for upset
+    // by limiting the effect to just the TiF series for the moment. We can extend or remove this
+    // as we (or editorial) like - assuming it doesn't break any of the platforms along the way, obvs.
+    val shouldPreserveHtmlInDescription =
+      tagId == "news/series/todayinfocus"
+
+    val description = Filtering.standfirst(standfirstOrTrail.getOrElse(""), preserveHtml = shouldPreserveHtmlInDescription) + membershipCta
 
     val url = acastProxy(asset.file.getOrElse(""))
 
@@ -232,9 +238,9 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
 
     val keywords = makeKeywordsList(podcast.tags.toSeq)
 
-    val subtitle = Filtering.standfirst(trailText.getOrElse(""), asHtml = false)
+    val subtitle = Filtering.standfirst(trailText.getOrElse(""), preserveHtml = false)
 
-    val summary = Filtering.standfirst(standfirstOrTrail.getOrElse(""), asHtml = false) + membershipCta
+    val summary = Filtering.standfirst(standfirstOrTrail.getOrElse(""), preserveHtml = false) + membershipCta
 
     val episodeImage: Option[String] = imageResizerSignatureSalt.filter(_.nonEmpty && isValidForEpisodicArtwork(podcast)).flatMap { salt =>
       val maybeThumbnailImageElements = podcast.elements.find(_.exists(el => el.relation == "thumbnail" && el.`type` == ElementType.Image))

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -193,7 +193,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
       if (useAcastProxy) "https://flex.acast.com/" + url.replace("https://", "") else url
     }
 
-    val description = Filtering.standfirst(standfirstOrTrail.getOrElse("")) + membershipCta
+    val description = Filtering.standfirst(standfirstOrTrail.getOrElse(""), asHtml = true) + membershipCta
 
     val url = acastProxy(asset.file.getOrElse(""))
 
@@ -232,9 +232,9 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
 
     val keywords = makeKeywordsList(podcast.tags.toSeq)
 
-    val subtitle = Filtering.standfirst(trailText.getOrElse(""))
+    val subtitle = Filtering.standfirst(trailText.getOrElse(""), asHtml = false)
 
-    val summary = Filtering.standfirst(standfirstOrTrail.getOrElse("")) + membershipCta
+    val summary = Filtering.standfirst(standfirstOrTrail.getOrElse(""), asHtml = false) + membershipCta
 
     val episodeImage: Option[String] = imageResizerSignatureSalt.filter(_.nonEmpty && isValidForEpisodicArtwork(podcast)).flatMap { salt =>
       val maybeThumbnailImageElements = podcast.elements.find(_.exists(el => el.relation == "thumbnail" && el.`type` == ElementType.Image))

--- a/test/com/gu/itunes/FilteringSpec.scala
+++ b/test/com/gu/itunes/FilteringSpec.scala
@@ -10,10 +10,17 @@ class FilteringSpec extends AnyFlatSpec with Matchers {
   it should "extract content inside <p>" in {
 
     val source = "<p>Only 7% of American women keep their last names when marrying. Columnist Jessica Valenti and guest Laurie Scheuble discuss why that is</p>"
-    val filtered = Filtering.standfirst(source)
+    val filtered = Filtering.standfirst(source, asHtml=false)
 
     val expected = "Only 7% of American women keep their last names when marrying. Columnist Jessica Valenti and guest Laurie Scheuble discuss why that is"
 
+    filtered should be(expected)
+  }
+
+  it should "retain links within standFirsts <p>" in {
+    val source = "<p>This is an introductory paragraph.</p><p>• Here we link to <a href=\\\"https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast\\\">another episode</a> from April 2023, and link to an article that is related to this episode <a href=\\\"https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood\\\">here</a>.</p>"
+    val filtered = Filtering.standfirst(source, asHtml=true)
+    val expected = "This is an introductory paragraph.• Here we link to <a href=\\\"https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast\\\">another episode</a> from April 2023, and link to an article that is related to this episode <a href=\\\"https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood\\\">here</a>."
     filtered should be(expected)
   }
 
@@ -23,7 +30,7 @@ class FilteringSpec extends AnyFlatSpec with Matchers {
 
     val source = """<p>The Guardian’s&nbsp;<a href=\"http://www.theguardian.com/profile/jessicavalenti\">Jessica Valenti</a>&nbsp;brings you interviews, advice and real life stories from the front lines of feminism. She talks about everything from periods or lack there of, to cyberbullying, objectification, crafting an equal and egalitarian relationship, abortions and sex education. This is the place for women and men to share their questions and thoughts about everyday issues facing women and feminism. Want to ask a question? Leave us a voicemail:&nbsp;<a href=\"tel:917-900-4577\">917-900-4577</a><br></p>"""
 
-    val filtered = Filtering.description(source)
+    val filtered = Filtering.description(source, asHtml=false)
 
     val expected = """The Guardian’s Jessica Valenti brings you interviews, advice and real life stories from the front lines of feminism. She talks about everything from periods or lack there of, to cyberbullying, objectification, crafting an equal and egalitarian relationship, abortions and sex education. This is the place for women and men to share their questions and thoughts about everyday issues facing women and feminism. Want to ask a question? Leave us a voicemail: 917-900-4577"""
 

--- a/test/com/gu/itunes/FilteringSpec.scala
+++ b/test/com/gu/itunes/FilteringSpec.scala
@@ -8,34 +8,40 @@ class FilteringSpec extends AnyFlatSpec with Matchers {
   behavior of "standfirst"
 
   it should "extract content inside <p>" in {
-
     val source = "<p>Only 7% of American women keep their last names when marrying. Columnist Jessica Valenti and guest Laurie Scheuble discuss why that is</p>"
-    val filtered = Filtering.standfirst(source, asHtml = false)
-
+    val filtered = Filtering.standfirst(source, preserveHtml = false)
     val expected = "Only 7% of American women keep their last names when marrying. Columnist Jessica Valenti and guest Laurie Scheuble discuss why that is"
-
     filtered should be(expected)
   }
 
-  it should "retain links within standFirsts <p>" in {
+  it should "retain a tags with href attribute and enforce rel=nofollow within standFirst's <p> when instructed" in {
     val source = "<p>This is an introductory paragraph.</p><p>• Here we link to <a href=\"https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast\">another episode</a> from April 2023, and link to an article that is related to this episode <a href=\"https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood\">here</a>.</p>"
-    val filtered = Filtering.standfirst(source, asHtml = true)
-    val expected = "This is an introductory paragraph. • Here we link to <a href=\"https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast\">another episode</a> from April 2023, and link to an article that is related to this episode <a href=\"https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood\">here</a>."
+    val filtered = Filtering.standfirst(source, preserveHtml = true)
+    val expected = "This is an introductory paragraph. • Here we link to <a href=\"https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast\" rel=\"nofollow\">another episode</a> from April 2023, and link to an article that is related to this episode <a href=\"https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood\" rel=\"nofollow\">here</a>."
+    filtered should be(expected)
+  }
+
+  it should "retain all tags defined by Safelist.simpleText within standFirst's <p> when instructed" in {
+    val source = "<p>This is a <strong>strong introductory</strong> paragraph.</p><p>• Here we <b>boldly</b> link to <a href=\"https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast\">another episode</a> from April 2023, and <em>emphasise this link</em> to an <i>italicised</i> article that is related to and <u>underscores</u> this episode <a href=\"https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood\">here</a>.</p>"
+    val filtered = Filtering.standfirst(source, preserveHtml = true)
+    val expected = "This is a <strong>strong introductory</strong> paragraph. • Here we <b>boldly</b> link to <a href=\"https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast\" rel=\"nofollow\">another episode</a> from April 2023, and <em>emphasise this link</em> to an <i>italicised</i> article that is related to and <u>underscores</u> this episode <a href=\"https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood\" rel=\"nofollow\">here</a>."
+    filtered should be(expected)
+  }
+
+  it should "remove all html from the standFirst <p> when instructed" in {
+    val source = "<p>This is a <strong>strong introductory</strong> paragraph.</p><p>• Here we <b>boldly</b> link to <a href=\"https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast\">another episode</a> from April 2023, and <em>emphasise this link</em> to an <i>italicised</i> article that is related to and <u>underscores</u> this episode <a href=\"https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood\">here</a>.</p>"
+    val filtered = Filtering.standfirst(source, preserveHtml = false)
+    val expected = "This is a strong introductory paragraph. • Here we boldly link to another episode from April 2023, and emphasise this link to an italicised article that is related to and underscores this episode here."
     filtered should be(expected)
   }
 
   behavior of "description"
 
-  it should "remove <br> and extract content inside <p>" in {
-
+  it should "remove <br>, extract content inside <p> and remove <a> tags but retain text from within" in {
     val source = """<p>The Guardian’s&nbsp;<a href=\"http://www.theguardian.com/profile/jessicavalenti\">Jessica Valenti</a>&nbsp;brings you interviews, advice and real life stories from the front lines of feminism. She talks about everything from periods or lack there of, to cyberbullying, objectification, crafting an equal and egalitarian relationship, abortions and sex education. This is the place for women and men to share their questions and thoughts about everyday issues facing women and feminism. Want to ask a question? Leave us a voicemail:&nbsp;<a href=\"tel:917-900-4577\">917-900-4577</a><br></p>"""
-
-    val filtered = Filtering.description(source, asHtml = false)
-
+    val filtered = Filtering.description(source)
     val expected = """The Guardian’s Jessica Valenti brings you interviews, advice and real life stories from the front lines of feminism. She talks about everything from periods or lack there of, to cyberbullying, objectification, crafting an equal and egalitarian relationship, abortions and sex education. This is the place for women and men to share their questions and thoughts about everyday issues facing women and feminism. Want to ask a question? Leave us a voicemail: 917-900-4577"""
-
     filtered should be(expected)
-
   }
 
 }

--- a/test/com/gu/itunes/FilteringSpec.scala
+++ b/test/com/gu/itunes/FilteringSpec.scala
@@ -10,7 +10,7 @@ class FilteringSpec extends AnyFlatSpec with Matchers {
   it should "extract content inside <p>" in {
 
     val source = "<p>Only 7% of American women keep their last names when marrying. Columnist Jessica Valenti and guest Laurie Scheuble discuss why that is</p>"
-    val filtered = Filtering.standfirst(source, asHtml=false)
+    val filtered = Filtering.standfirst(source, asHtml = false)
 
     val expected = "Only 7% of American women keep their last names when marrying. Columnist Jessica Valenti and guest Laurie Scheuble discuss why that is"
 
@@ -18,9 +18,9 @@ class FilteringSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "retain links within standFirsts <p>" in {
-    val source = "<p>This is an introductory paragraph.</p><p>• Here we link to <a href=\\\"https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast\\\">another episode</a> from April 2023, and link to an article that is related to this episode <a href=\\\"https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood\\\">here</a>.</p>"
-    val filtered = Filtering.standfirst(source, asHtml=true)
-    val expected = "This is an introductory paragraph.• Here we link to <a href=\\\"https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast\\\">another episode</a> from April 2023, and link to an article that is related to this episode <a href=\\\"https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood\\\">here</a>."
+    val source = "<p>This is an introductory paragraph.</p><p>• Here we link to <a href=\"https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast\">another episode</a> from April 2023, and link to an article that is related to this episode <a href=\"https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood\">here</a>.</p>"
+    val filtered = Filtering.standfirst(source, asHtml = true)
+    val expected = "This is an introductory paragraph. • Here we link to <a href=\"https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast\">another episode</a> from April 2023, and link to an article that is related to this episode <a href=\"https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood\">here</a>."
     filtered should be(expected)
   }
 
@@ -30,7 +30,7 @@ class FilteringSpec extends AnyFlatSpec with Matchers {
 
     val source = """<p>The Guardian’s&nbsp;<a href=\"http://www.theguardian.com/profile/jessicavalenti\">Jessica Valenti</a>&nbsp;brings you interviews, advice and real life stories from the front lines of feminism. She talks about everything from periods or lack there of, to cyberbullying, objectification, crafting an equal and egalitarian relationship, abortions and sex education. This is the place for women and men to share their questions and thoughts about everyday issues facing women and feminism. Want to ask a question? Leave us a voicemail:&nbsp;<a href=\"tel:917-900-4577\">917-900-4577</a><br></p>"""
 
-    val filtered = Filtering.description(source, asHtml=false)
+    val filtered = Filtering.description(source, asHtml = false)
 
     val expected = """The Guardian’s Jessica Valenti brings you interviews, advice and real life stories from the front lines of feminism. She talks about everything from periods or lack there of, to cyberbullying, objectification, crafting an equal and egalitarian relationship, abortions and sex education. This is the place for women and men to share their questions and thoughts about everyday issues facing women and feminism. Want to ask a question? Leave us a voicemail: 917-900-4577"""
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We currently (and have [since PR #29 in 2016](https://github.com/guardian/itunes-rss/pull/29)) remove all HTML from RSS item description fields. But then we append the supporter revenue links back in again anyway and this doesn't appear to break Apple or Spotify podcasts even though it does break [feed validation](http://www.feedvalidator.org/check.cgi?url=https%3A%2F%2Fwww.theguardian.com%2Fnews%2Fseries%2Ftodayinfocus%2Fpodcast.xml).

We recently received a request from editorial to re-enable these links, and as we're already breaking the validator but the links appear to work anyway, we figured we'd try it.

## How to test

Have run it locally, here's a before and after
Demonstrating links:
```
Before:
<description>Helen Pidd and Alexandra Topping have been close friends for almost 20 years. But struggles with fertility and new motherhood tested their bond to the limit. • Listen to our Embracing a childfree life episode, from April 2023, on Helen’s experience of IVF treatment and meeting other childfree people, and read Helen and Lexy’s account of their friendship here.. Help support our independent journalism at <a href="https://www.theguardian.com/infocus">theguardian.com/infocus</a></description>

After:
<description>Helen Pidd and Alexandra Topping have been close friends for almost 20 years. But struggles with fertility and new motherhood tested their bond to the limit. • Listen to our <a href="https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast" rel="nofollow">Embracing a childfree life</a> episode, from April 2023, on Helen’s experience of IVF treatment and meeting other childfree people, and read Helen and Lexy’s account of their friendship <a href="https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood" rel="nofollow">here</a>.. Help support our independent journalism at <a href="https://www.theguardian.com/infocus">theguardian.com/infocus</a></description>
```

Demonstrating other HTML:
```
Before:
<description>Political correspondent Kiran Stacey traces the allegations of corruption against Labour MP Tulip Siddiq that caused her to resign from her ministerial role in Keir Starmer’s government. Help support our independent journalism at <a href="https://www.theguardian.com/infocus">theguardian.com/infocus</a></description>

After:
<description>Political correspondent <strong>Kiran Stacey </strong>traces the allegations of corruption against Labour MP Tulip Siddiq that caused her to resign from her ministerial role in Keir Starmer’s government. Help support our independent journalism at <a href="https://www.theguardian.com/infocus">theguardian.com/infocus</a></description>
```

## How can we measure success?

If we deploy it and we get working links (and other supported HTML) in the descriptions, success!

## Have we considered potential risks?

As it is a feed validation breaking feature, it's possible support for these links may not be widely supported by podcast platforms, so we'll need to try to check everything that we send out in as many places as possible before we can say we're done. It may also stop working in future if the platforms tighten up their adoption of the rules.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A

