### PR TITLE
Setup for TiF episodic artwork

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -15,12 +15,12 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
   private def isValidForEpisodicArtwork(podcast: Content): Boolean = {
     (tagId == "lifeandstyle/series/comforteatingwithgracedent" &&
       podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2024, 6, 11, 0, 0).getMillis)) ||
-      (tagId == "australia-news/series/full-story" &&
-        podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2024, 10, 8, 0, 0).getMillis)) ||
-        (tagId == "news/series/guardian-australia-podcast-series" &&
-          podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2022, 10, 1, 0, 0).getMillis)) ||
-          (tagId == "news/series/todayinfocus" &&
-            podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2125, 1, 1, 0, 0).getMillis)) // TODO: update this date when we know what it should be
+    (tagId == "australia-news/series/full-story" &&
+      podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2024, 10, 8, 0, 0).getMillis)) ||
+    (tagId == "news/series/guardian-australia-podcast-series" &&
+      podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2022, 10, 1, 0, 0).getMillis)) ||
+    (tagId == "news/series/todayinfocus" &&
+      podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2025, 3, 10, 0, 0).getMillis))
   }
 
   def toXml: Node = {

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -20,7 +20,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
     (tagId == "news/series/guardian-australia-podcast-series" &&
       podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2022, 10, 1, 0, 0).getMillis)) ||
     (tagId == "news/series/todayinfocus" &&
-      podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2025, 3, 10, 0, 0).getMillis))
+      podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2025, 3, 13, 0, 0).getMillis))
   }
 
   def toXml: Node = {

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -18,7 +18,9 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
       (tagId == "australia-news/series/full-story" &&
         podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2024, 10, 8, 0, 0).getMillis)) ||
         (tagId == "news/series/guardian-australia-podcast-series" &&
-          podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2022, 10, 1, 0, 0).getMillis))
+          podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2022, 10, 1, 0, 0).getMillis)) ||
+          (tagId == "news/series/todayinfocus" &&
+            podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2125, 1, 1, 0, 0).getMillis)) // TODO: update this date when we know what it should be
   }
 
   def toXml: Node = {


### PR DESCRIPTION
## What does this change?

Gets us ready to start using auto-cropped episodic artwork for the Today in Focus series. We're waiting for the actual start date to be provided, so I set it to 100 years in the future for the moment. We ought to get there before then, but if we don't it won't be my problem 😆 

## How to test

We have experience of other series that have followed this pattern before, so from a technical point of view this should be good to merge and go when the editorial templates are ready and the date is adjusted.

## How can we measure success?

We should expect images to arrive per episode vey quickly on e.g. Spotify. Apple podcasts may take longer.

## Have we considered potential risks?

If it is activated too soon, we may generate substandard image crops. Not the end of the world, generally because most images crop quite well anyway, but we'd prefer not to be in that situation.

## Images

Not available yet. You can look at e.g. [Comfort Eating on Spotify](https://open.spotify.com/episode/0kpmO3rmpWzI8j1T5QTHks) for what we might expect though.

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
