### PR TITLE
Allow html in description for US politics weekly from Apr 4 2025

### DIFF
--- a/app/com/gu/itunes/Filtering.scala
+++ b/app/com/gu/itunes/Filtering.scala
@@ -12,10 +12,10 @@ object Filtering {
   private[this] def filter(input: String, preserveHtml: Boolean): String = {
 
     val doc = Jsoup.parse(input)
-    doc.select("br").remove
 
     val safeList = if (preserveHtml) {
       Safelist.simpleText()
+        .addTags("br")
         .addAttributes("a", "href")
         .addEnforcedAttribute("a", "rel", "nofollow")
     } else {
@@ -25,7 +25,7 @@ object Filtering {
     val cleaned = Jsoup.clean(doc.outerHtml(), safeList)
 
     if (preserveHtml) {
-      Jsoup.parse(cleaned).body.html()
+      Jsoup.parse(cleaned).body.html() // need this as .html() for the links etc to work!
     } else {
       Jsoup.parse(cleaned).text()
     }

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -196,10 +196,12 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
     }
 
     // enabling html in descriptions is a bit of an unknown so we'll restrict the potential for upset
-    // by limiting the effect to just the TiF series for the moment. We can extend or remove this
-    // as we (or editorial) like - assuming it doesn't break any of the platforms along the way, obvs.
+    // by limiting the effect to just the TiF series generally and Politics Weekly America from April 4th 2025
+    // for the moment. We can extend or remove this as we (or editorial) like - assuming it doesn't break
+    // any of the platforms along the way, obvs.
     val shouldPreserveHtmlInDescription =
-      tagId == "news/series/todayinfocus"
+      tagId == "news/series/todayinfocus" ||
+      (tagId == "politics/series/politics-weekly-america" && podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2025, 4, 4, 0, 0).getMillis))
 
     val description = Filtering.standfirst(standfirstOrTrail.getOrElse(""), preserveHtml = shouldPreserveHtmlInDescription) + membershipCta
 

--- a/test/com/gu/itunes/FilteringSpec.scala
+++ b/test/com/gu/itunes/FilteringSpec.scala
@@ -28,6 +28,13 @@ class FilteringSpec extends AnyFlatSpec with Matchers {
     filtered should be(expected)
   }
 
+  it should "retain br tags from within the standFirst when instructed" in {
+    val source = "<p>This is a <strong>strong introductory</strong> paragraph.</p><p>• Here we <b>boldly</b> link to <a href=\"https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast\">another episode</a> from April 2023, and <em>emphasise this link</em> to an <i>italicised</i> article that is related to and <u>underscores</u><br>(on a new line) this episode <a href=\"https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood\">here</a>.</p>"
+    val filtered = Filtering.standfirst(source, preserveHtml = true)
+    val expected = "This is a <strong>strong introductory</strong> paragraph. • Here we <b>boldly</b> link to <a href=\"https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast\" rel=\"nofollow\">another episode</a> from April 2023, and <em>emphasise this link</em> to an <i>italicised</i> article that is related to and <u>underscores</u>\n<br>\n (on a new line) this episode <a href=\"https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood\" rel=\"nofollow\">here</a>."
+    filtered should be(expected)
+  }
+
   it should "remove all html from the standFirst <p> when instructed" in {
     val source = "<p>This is a <strong>strong introductory</strong> paragraph.</p><p>• Here we <b>boldly</b> link to <a href=\"https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast\">another episode</a> from April 2023, and <em>emphasise this link</em> to an <i>italicised</i> article that is related to and <u>underscores</u> this episode <a href=\"https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood\">here</a>.</p>"
     val filtered = Filtering.standfirst(source, preserveHtml = false)

--- a/test/com/gu/itunes/FilteringSpec.scala
+++ b/test/com/gu/itunes/FilteringSpec.scala
@@ -36,7 +36,7 @@ class FilteringSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "remove all html from the standFirst <p> when instructed" in {
-    val source = "<p>This is a <strong>strong introductory</strong> paragraph.</p><p>• Here we <b>boldly</b> link to <a href=\"https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast\">another episode</a> from April 2023, and <em>emphasise this link</em> to an <i>italicised</i> article that is related to and <u>underscores</u> this episode <a href=\"https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood\">here</a>.</p>"
+    val source = "<p>This is a <strong>strong introductory</strong> paragraph.</p><p>• Here we <b>boldly</b> link to <a href=\"https://www.theguardian.com/news/audio/2023/apr/24/embracing-a-childfree-life-podcast\">another episode</a> from April 2023, and <em>emphasise this link</em> to an <i>italicised</i> article that is<br> related to and <u>underscores</u> this episode <a href=\"https://www.theguardian.com/lifeandstyle/2024/nov/16/friendship-after-motherhood\">here</a>.</p>"
     val filtered = Filtering.standfirst(source, preserveHtml = false)
     val expected = "This is a strong introductory paragraph. • Here we boldly link to another episode from April 2023, and emphasise this link to an italicised article that is related to and underscores this episode here."
     filtered should be(expected)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Editorial frequently write specific links into the trail text of podcasts and wonder why this isn't reflected out on the podcast platforms. Typically this is because we explicitly remove html from there as it breaks some feed spec validation checks.

However, since #170 we have seen that some of these elements are at least rendered, so we're going to try the same thing for Politics Weekly America.

The difference with this particular series though is that in addition to links, `<br>` elements are used instead of straightforward punctuation, and we don't know how well or badly those will be received by the platforms. So we're going to start with the minimum possible impact and include episodes launched on or after April 4th 2025 as we know there is only one (at the time of creating this PR) that will be affected.

## How to test

The unit tests show that it's doing the correct thing. We don't have a CODE version of this, so it's testing in production. Yay.

## How can we measure success?

If we receive zero complaints, and if the line breaks and links are rendered... success!

## Have we considered potential risks?

This may not be well received. In that case we revert this PR wholesale and go back to editorial with style guidance that is better behaved.

## Images

Not available yet.

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A

