### PR TITLE
Enable episodic artwork for blackbox podcast

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -20,7 +20,9 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
     (tagId == "news/series/guardian-australia-podcast-series" &&
       podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2022, 10, 1, 0, 0).getMillis)) ||
     (tagId == "news/series/todayinfocus" &&
-      podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2025, 3, 13, 0, 0).getMillis))
+      podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2025, 3, 13, 0, 0).getMillis)) ||
+    (tagId == "technology/series/blackbox" &&
+      podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2025, 5, 22, 0, 0).getMillis))
   }
 
   def toXml: Node = {


### PR DESCRIPTION
## What does this change?

Adds the blackbox series tag and a start date of today (Thursday 22nd May, 2025) for the first inclusion of the episodic artwork for that series.

## How to test

I have attempted to test this by modifying the date to be in the past (`DateTime(2020, 5, 22, 0, 0)`), running the application locally and visiting:

http://localhost:9000/technology/series/blackbox/podcast.xml

~However, the expected images don't appear in the way Justin noted [here](https://github.com/guardian/itunes-rss/pull/164). I think this might be because I didn't run this beforehand, as per the [instructions](https://github.com/guardian/itunes-rss?tab=readme-ov-file#to-run-locally):~

```
export FASTLY_SALT=astringthatactuallyworkswillbeneeded
```

~Where do I get this salt from?~

UPDATE: we got this working by pulling the production salt out out of AWS:

1) Log into AWS in the CAPI account
2) Go to the [Secrets Manager](https://eu-west-1.console.aws.amazon.com/secretsmanager)
3) Locate the salt. The path is `/PROD/content-api/podcasts-rss/fastlyImageResizerSignatureSalt`
4) Press "Retrieve secret value" and copy it
5) Run `export FASTLY_SALT=<SALT_GOES_HERE>`

Then the images appear as expected.

## How can we measure success?

The artwork should appear when and where it's supposed to