### PR TITLE
Enable episodic artwork for all blackbox episodes

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -21,8 +21,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, adFre
       podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2022, 10, 1, 0, 0).getMillis)) ||
     (tagId == "news/series/todayinfocus" &&
       podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2025, 3, 13, 0, 0).getMillis)) ||
-    (tagId == "technology/series/blackbox" &&
-      podcast.webPublicationDate.exists(wpd => new DateTime(wpd.dateTime).getMillis >= new DateTime(2025, 5, 22, 0, 0).getMillis))
+    tagId == "technology/series/blackbox"
   }
 
   def toXml: Node = {


### PR DESCRIPTION
## What does this change?

Removes the date restriction introduced here https://github.com/guardian/itunes-rss/pull/178 so that all episodes in the blackbox series have episodic art enabled instead of just ones after 22/5/2025.

## How to test

See previous PR for details. 

All episodes listed here:

http://localhost:9000/technology/series/blackbox/podcast.xml

should now have images.

