### PR TITLE
feat(cdk): Enable load balancer access logging 

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -3,5 +3,5 @@ import { App } from "aws-cdk-lib";
 import { PodcastsRss } from "../lib/podcasts-rss";
 
 const app = new App();
-new PodcastsRss(app, "PodcastsRss-CODE", { stack: "content-api", stage: "CODE" });
-new PodcastsRss(app, "PodcastsRss-PROD", { stack: "content-api", stage: "PROD" });
+new PodcastsRss(app, "PodcastsRss-CODE", { stack: "content-api", stage: "CODE", env: { region: "eu-west-1" } });
+new PodcastsRss(app, "PodcastsRss-PROD", { stack: "content-api", stage: "PROD", env: { region: "eu-west-1" } });

--- a/cdk/lib/__snapshots__/podcasts-rss.test.ts.snap
+++ b/cdk/lib/__snapshots__/podcasts-rss.test.ts.snap
@@ -319,11 +319,7 @@ exports[`The PodcastsRss stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:kinesis:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:kinesis:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -355,11 +351,7 @@ exports[`The PodcastsRss stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -733,11 +725,7 @@ exports[`The PodcastsRss stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -756,11 +744,7 @@ exports[`The PodcastsRss stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -816,11 +800,7 @@ exports[`The PodcastsRss stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -836,11 +816,7 @@ exports[`The PodcastsRss stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:secretsmanager:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:secretsmanager:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -952,11 +928,7 @@ exports[`The PodcastsRss stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },

--- a/cdk/lib/__snapshots__/podcasts-rss.test.ts.snap
+++ b/cdk/lib/__snapshots__/podcasts-rss.test.ts.snap
@@ -20,6 +20,7 @@ exports[`The PodcastsRss stack matches the snapshot 1`] = `
       "GuWazuhAccess",
       "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
+      "GuStringParameter",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuAlb5xxPercentageAlarm",
@@ -42,6 +43,11 @@ exports[`The PodcastsRss stack matches the snapshot 1`] = `
     "AMIPodcastsrss": {
       "Description": "Amazon Machine Image ID for the app podcasts-rss. Use this in conjunction with AMIgo to keep AMIs up to date.",
       "Type": "AWS::EC2::Image::Id",
+    },
+    "AccessLoggingBucket": {
+      "Default": "/account/services/access-logging/bucket",
+      "Description": "S3 bucket to store your access logs",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
@@ -567,6 +573,20 @@ exports[`The PodcastsRss stack matches the snapshot 1`] = `
           {
             "Key": "deletion_protection.enabled",
             "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.bucket",
+            "Value": {
+              "Ref": "AccessLoggingBucket",
+            },
+          },
+          {
+            "Key": "access_logs.s3.prefix",
+            "Value": "application-load-balancer/TEST/content-api/podcasts-rss",
           },
         ],
         "Scheme": "internet-facing",

--- a/cdk/lib/podcasts-rss.test.ts
+++ b/cdk/lib/podcasts-rss.test.ts
@@ -5,7 +5,7 @@ import { PodcastsRss } from "./podcasts-rss";
 describe("The PodcastsRss stack", () => {
   it("matches the snapshot", () => {
     const app = new App();
-    const stack = new PodcastsRss(app, "PodcastsRss", { stack: "content-api", stage: "TEST" });
+    const stack = new PodcastsRss(app, "PodcastsRss", { stack: "content-api", stage: "TEST", env: { region: "eu-west-1" } });
     const template = Template.fromStack(stack);
     expect(template.toJSON()).toMatchSnapshot();
   });

--- a/cdk/lib/podcasts-rss.ts
+++ b/cdk/lib/podcasts-rss.ts
@@ -72,6 +72,11 @@ export class PodcastsRss extends GuStack {
         }
       },
       vpc,
+      accessLogging: {
+        enabled: true,
+        // This is the prefix pattern DevX assumes so that the logs can be searched in Grafana and shown on the Availability dashboard.
+        prefix: `application-load-balancer/${this.stage}/${this.stack}/podcasts-rss`,
+      }
     });
 
     app.loadBalancer.addListener("HttpToHttps", {


### PR DESCRIPTION
> [!NOTE]
> Easiest to review [commit by commit](https://github.com/guardian/itunes-rss/pull/181/commits).

## What does this change?
This change enables access logging on the load balancer, shipping logs to the organisational S3 bucket which is queryable in Grafana. See also https://github.com/guardian/aws-account-setup/pull/352.

We want to understand which clients are accessing the load balancer. Searching the access logs enables us to gain this insight.

## How to test
After [deploying `main` to CODE](https://riffraff.gutools.co.uk/deployment/view/b8cc0939-f4ca-4e1b-b94f-98e6ab993633)[^1], I've successfully [deployed this branch](https://riffraff.gutools.co.uk/deployment/view/e2b6fc4f-2f22-48ce-8322-3f2fb8b10a55). The access logs are now [queryable within Grafana](https://metrics.gutools.co.uk/goto/tgC9_SsHg?orgId=1).

## How can we measure success?
Access logs for this service are searchable within Grafana.

## Have we considered potential risks?
None. These logs are produced at the infrastructure level by AWS - there's no impact to the application's performance.

[^1]: This is because there wasn't a running CODE stack. Deployed in "dangerous" mode to create one; this stopped Riff-Raff from performing any preflight checks.