### PR TITLE
Use new episode numbering and type fields from CAPI

### DIFF
--- a/app/com/gu/itunes/iTunesRssFeed.scala
+++ b/app/com/gu/itunes/iTunesRssFeed.scala
@@ -106,7 +106,8 @@ object iTunesRssFeed {
               for {
                 podcastContent <- contents
                 asset <- getFirstAudioAsset(podcastContent)
-              } yield new iTunesRssItem(podcastContent, tag.id, asset, adFree, Some(podcast), imageResizerSalt).toXml
+                element <- getFirstAudioElement(podcastContent)
+              } yield new iTunesRssItem(podcastContent, tag.id, asset, element, adFree, Some(podcast), imageResizerSalt).toXml
             }
           </channel>
         </rss>
@@ -126,6 +127,13 @@ object iTunesRssFeed {
     } yield asset
   }
 
+  private def getFirstAudioElement(podcast: Content): Option[BlockElement] = {
+    for {
+      blocks <- podcast.blocks
+      main <- blocks.main
+      element <- main.elements.find(_.`type` == ElementType.Audio)
+    } yield element
+  }
 }
 
 class CategoryRss(val category: PodcastCategory) {

--- a/build.sbt
+++ b/build.sbt
@@ -12,13 +12,13 @@ val root = Project("podcasts-rss", file("."))
   .settings(
     libraryDependencies ++= Seq(
       "org.jsoup" % "jsoup" % "1.18.1",
-      "com.gu" %% "content-api-client" % "35.0.0",
+      "com.gu" %% "content-api-client" % "36.0.0-PREVIEW.bump-capi-models-to-bring-in-new-podcast-fields.2025-08-28T1530.804e7d48",
       "com.squareup.okhttp3" % "okhttp" % "4.12.0", // SNYK-JAVA-ORGJETBRAINSKOTLIN-2393744, SNYK-JAVA-COMSQUAREUPOKIO-5820002
       "software.amazon.awssdk" % "secretsmanager" % "2.25.32", // SNYK-JAVA-IONETTY-1042268
       "org.scalactic" %% "scalactic" % "3.2.19",
       "org.scalatest" %% "scalatest" % "3.2.19" % "test",
       "net.logstash.logback" % "logstash-logback-encoder" % "7.4",
-      "com.gu" %% "content-api-models-json" % "29.0.0" % "test", // keeping in line with imports from content-api-client
+      "com.gu" %% "content-api-models-json" % "30.0.0-PREVIEW.add-new-podcast-fields.2025-08-28T1513.9b26e163" % "test", // keeping in line with imports from content-api-client
       "com.gu" %% "simple-configuration-core" % "2.0.0",
       "com.gu.play-secret-rotation" %% "play-v30" % "8.2.1",
       "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "8.2.1",

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val root = Project("podcasts-rss", file("."))
       "org.scalactic" %% "scalactic" % "3.2.19",
       "org.scalatest" %% "scalatest" % "3.2.19" % "test",
       "net.logstash.logback" % "logstash-logback-encoder" % "7.4",
-      "com.gu" %% "content-api-models-json" % "30.0.0-PREVIEW.add-new-podcast-fields.2025-08-28T1513.9b26e163" % "test", // keeping in line with imports from content-api-client
+      "com.gu" %% "content-api-models-json" % "30.0.0" % "test", // keeping in line with imports from content-api-client
       "com.gu" %% "simple-configuration-core" % "2.0.0",
       "com.gu.play-secret-rotation" %% "play-v30" % "8.2.1",
       "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "8.2.1",

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ val root = Project("podcasts-rss", file("."))
   .settings(
     libraryDependencies ++= Seq(
       "org.jsoup" % "jsoup" % "1.18.1",
-      "com.gu" %% "content-api-client" % "36.0.0-PREVIEW.bump-capi-models-to-bring-in-new-podcast-fields.2025-08-28T1530.804e7d48",
+      "com.gu" %% "content-api-client" % "36.0.0",
       "com.squareup.okhttp3" % "okhttp" % "4.12.0", // SNYK-JAVA-ORGJETBRAINSKOTLIN-2393744, SNYK-JAVA-COMSQUAREUPOKIO-5820002
       "software.amazon.awssdk" % "secretsmanager" % "2.25.32", // SNYK-JAVA-IONETTY-1042268
       "org.scalactic" %% "scalactic" % "3.2.19",

--- a/test/com/gu/itunes/AcastProxySpec.scala
+++ b/test/com/gu/itunes/AcastProxySpec.scala
@@ -14,14 +14,16 @@ class AcastProxySpec extends AnyFlatSpec with Matchers with ItunesTestData {
   it should "use the acast proxy" in {
     val newItem: Content = testContent.head
     val asset: Asset = testContent.head.elements.head.head.assets.find(_.`type` == AssetType.Audio).get
-    val item = new iTunesRssItem(newItem, tag, asset, imageResizerSignatureSalt = imageResizerSalt)
+    val element: BlockElement = BlockElement(`type` = ElementType.Audio)
+    val item = new iTunesRssItem(newItem, tag, asset, element, imageResizerSignatureSalt = imageResizerSalt)
     (item.toXml.head \\ "enclosure" \ "@url").text shouldBe "https://flex.acast.com/audio.guim.co.uk/2017/05/30-51066-gnl.rs.brexit.20170530.thelastbeforethelection.mp3"
   }
 
   it should "use Guardian origin" in {
     val oldItem: Content = testContent(1)
     val asset: Asset = testContent(1).elements.head.head.assets.find(_.`type` == AssetType.Audio).get
-    val item = new iTunesRssItem(oldItem, tag, asset, imageResizerSignatureSalt = imageResizerSalt)
+    val element: BlockElement = BlockElement(`type` = ElementType.Audio)
+    val item = new iTunesRssItem(oldItem, tag, asset, element, imageResizerSignatureSalt = imageResizerSalt)
     (item.toXml.head \\ "enclosure" \ "@url").text shouldBe "https://audio.guim.co.uk/2017/05/24-54013-gnl.rs.brexit.20170524.negotiationsguidelines.mp3"
   }
 

--- a/test/com/gu/itunes/ItunesTestData.scala
+++ b/test/com/gu/itunes/ItunesTestData.scala
@@ -35,9 +35,13 @@ trait ItunesTestData {
   }
 
   // content.guardianapis.com/technology/series/blackbox?show-fields=webTitle%2CwebPublicationDate%2Cstandfirst%2CtrailText%2CinternalComposerCode&show-elements=audio&show-tags=keyword&page-size=3
-  // contains episode number in web title
   val itunesCapiResponseEpisodeNumber: ItemResponse = {
     val json = loadJson("itunes-capi-episode-number.json")
+    parseJson[ItemResponse](json)
+  }
+
+  val itunesCapiResponseNoEpisodeNumber: ItemResponse = {
+    val json = loadJson("itunes-capi-no-episode-number.json")
     parseJson[ItemResponse](json)
   }
 

--- a/test/resources/itunes-capi-no-episode-number.json
+++ b/test/resources/itunes-capi-no-episode-number.json
@@ -175,10 +175,7 @@
                 "audioTypeData": {
                   "durationMinutes": 41,
                   "durationSeconds": 16,
-                  "clean": true,
-                  "podcastEpisodeNumber": 6,
-                  "podcastSeasonNumber": 1,
-                  "podcastEpisodeType": "bonus"
+                  "clean": true
                 }
               }
             ]


### PR DESCRIPTION
## What does this change?

Pulls in the new fields from CAPI:

- `podcastEpisodeNumber` (optional) - the episode number of the podcast
- `podcastSeasonNumber`(optional) - the season number of the podcast

In order to more robustly model episode numbering for podcasts with type `serial`.

This will supersede our current approach which relies on episode numbering information being present in the `webTitle` field: https://github.com/guardian/itunes-rss/pull/153.

Furthermore, pulls in the new field:

- `podcastEpisodeType` (optional) - the episode type of the podcast. Can be one of full, trailer or bonus. If absent, we assume it's a full episode

## How to test

Unit tests should pass.

Hard to test beyond that until we have production data coming through with the new fields set.

## How can we measure success?

All podcasts of type `serial` can have their episode and season numbering modelled properly. We also support the new field `itunes:episodeType`.

## Have we considered potential risks?

Not risky.

## Related PRs

- [flexible-model](https://github.com/guardian/flexible-model/pull/82)
- [flexible-content](https://github.com/guardian/flexible-content/pull/5768)
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3149)
- [content-api (ES mappings)](https://github.com/guardian/content-api/pull/3180)
- [content-api-models](https://github.com/guardian/content-api-models/pull/262) 
- [content-api (Concierge) ](https://github.com/guardian/content-api/pull/3150)
- [content-api-scala-client](https://github.com/guardian/content-api-scala-client/pull/445)
- [itunes-rss](https://github.com/guardian/itunes-rss/pull/183) <- you are here