### PR TITLE
Request main block when querying CAPI

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -64,6 +64,7 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
       .showElements("audio,image")
       .showTags("keyword")
       .showFields("webTitle,webPublicationDate,standfirst,trailText,internalComposerCode")
+      .showBlocks("main")
 
     def fetchItemsWithPagination(query: ItemQuery, page: Int = 1, resps: Seq[ItemResponse] = Seq.empty): Future[Seq[ItemResponse]] = {
       logger.debug("Fetching page: " + page + " with page size: " + pageSize)


### PR DESCRIPTION
## What does this change?

This recent change https://github.com/guardian/itunes-rss/pull/183 started accessing `blocks` in the CAPI response. You can see it happening [here](https://github.com/guardian/itunes-rss/blob/d45a55e59edf823047cbc1eca13b4975f33393e5/app/com/gu/itunes/iTunesRssFeed.scala#L132).

However CAPI only includes `blocks` in the response when `show-blocks` is set in the query parameters.

Because this was not the case, the feed was not being populated correctly. This PR fixes that issue.

## How to test

Run locally and ensure any podcast feed is correctly populated. For example:

http://localhost:9000/news/series/todayinfocus/podcast.xml

| Before | After |
|--------|--------|
| <img width="1920" height="1015" alt="Screenshot 2025-09-05 at 14 33 11" src="https://github.com/user-attachments/assets/5c53cdf1-c7a5-4681-8693-5c8a5c10cff4" /> | <img width="1901" height="1015" alt="Screenshot 2025-09-05 at 14 30 55" src="https://github.com/user-attachments/assets/042738f3-0743-4727-86ef-31c820b4a5b8" /> |