### PR TITLE
Make episodeType lowercase

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -37,7 +37,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, eleme
 
     val episodeNumber = if (isSerial) element.audioTypeData.flatMap(_.podcastEpisodeNumber) else None
     val seasonNumber = if (isSerial) element.audioTypeData.flatMap(_.podcastSeasonNumber) else None
-    val episodeType = element.audioTypeData.flatMap(_.podcastEpisodeType)
+    val episodeType = element.audioTypeData.flatMap(_.podcastEpisodeType.map(_.name.toLowerCase))
 
     val lastModified = podcast.webPublicationDate.map(date => new DateTime(date.dateTime)).getOrElse(DateTime.now)
 

--- a/test/com/gu/itunes/ItunesRssItemSpec.scala
+++ b/test/com/gu/itunes/ItunesRssItemSpec.scala
@@ -145,7 +145,7 @@ class ItunesRssItemSpec extends AnyFlatSpec with ItunesTestData with Matchers wi
 
     val episodeTypeTag = (rssItem \ "episodeType").head
     episodeTypeTag.prefix should be("itunes")
-    episodeTypeTag.text should be("Bonus")
+    episodeTypeTag.text should be("bonus")
   }
 
   it should "not set itunes:episode or itunes:season when the podcast does not have type 'serial'" in {


### PR DESCRIPTION
## What does this change?

Follows on from https://github.com/guardian/itunes-rss/pull/183

It wasn't clear from the documentation, but this sample feed suggests values of `itunes:episodeType` should be lowercase:

https://help.apple.com/itc/podcasts_connect/en.lproj/itcbaf351599.html

So instead of sending:

```
<itunes:episodeType>Trailer</itunes:episodeType>
```

we should send:

```
<itunes:episodeType>trailer</itunes:episodeType>
```

## How to test

Run locally and visit:

http://localhost:9000/australia-news/series/breathless-the-death-of-david-dungay-jnr/podcast.xml

And note `episodeType` is now lowercase:

<img width="815" height="290" alt="Screenshot 2025-09-08 at 11 37 30" src="https://github.com/user-attachments/assets/b63aa7ef-92cb-4dd1-9266-261380bdabef" />

