### PR TITLE
Update football weekly description

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -89,7 +89,7 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, eleme
             ""
         } else if (tagId == "football/series/footballweekly") {
           if (lastModified.isAfter(footballWeekly))
-            """. Help support our independent journalism at <a href="https://www.theguardian.com/footballweeklypod">theguardian.com/footballweeklypod</a>"""
+            """. Help support our independent journalism at <a href="https://www.theguardian.com/footballweeklypod">theguardian.com/footballweeklypod</a>. Watch us on YouTube: <a href="https://www.youtube.com/@FootballWeeklyPodcast">https://www.youtube.com/@FootballWeeklyPodcast</a>"""
           else ""
         } else {
           ""


### PR DESCRIPTION
## What does this change?

Appends a new line to the end of the description field for the football weekly podcast.

This was requested by Phil Maynard.

## How to test

Run locally and visit:

http://localhost:9000/football/series/footballweekly/podcast.xml

## Images

| Before | After |
|--------|--------|
| <img width="854" height="64" alt="Screenshot 2026-01-15 at 11 43 24" src="https://github.com/user-attachments/assets/24518a0c-a415-4702-bb4b-338610fae14e" /> | <img width="868" height="94" alt="Screenshot 2026-01-15 at 11 42 57" src="https://github.com/user-attachments/assets/1c37934b-504a-45d9-aa82-a04af42a79d5" /> | 


