### PR TITLE
Disable flex.acast for reverberate

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -154,8 +154,9 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, eleme
           "society/series/innermost")),
         AcastLaunchGroup(new DateTime(2020, 11, 25, 0, 0), Seq(
           "australia-news/series/temporary")),
-        AcastLaunchGroup(new DateTime(2021, 1, 19, 0, 0), Seq(
-          "music/series/reverberate")),
+//  Reverberate has been transferred to Acast hosted platform
+//        AcastLaunchGroup(new DateTime(2021, 1, 19, 0, 0), Seq(
+//          "music/series/reverberate")),
         AcastLaunchGroup(new DateTime(2021, 6, 8, 0, 0), Seq(
           "lifeandstyle/series/comforteatingwithgracedent")),
         AcastLaunchGroup(new DateTime(2021, 9, 1, 0, 0), Seq(


### PR DESCRIPTION
## What does this change?

In preparation for moving Reverberate to Acast's platform instead of Acast Flex, we need to disable Acast Flex for this podcast.

We are fairly sure that any existing links to flex.acast for this podcast (e.g. in Apps or DCR) will still work. But we will test that once the migration is done.