### PR TITLE
Redirect Reverberate to Acast

### DIFF
--- a/app/com/gu/itunes/Redirection.scala
+++ b/app/com/gu/itunes/Redirection.scala
@@ -15,13 +15,19 @@ object Redirection {
 
   val BaseUrl = "https://www.theguardian.com"
 
-  val redirectsMapping = Map[String, String](
-    "film/series/filmweekly" -> "film/series/the-dailies-podcast",
-    "technology/series/techweekly" -> "technology/series/chips-with-everything",
-    "politics/series/politics-for-humans" -> "us-news/series/politics-for-humans",
-    "australia-news/series/token-podcast" -> "society/series/token",
-    "membership/series/guardian-live-podcast" -> "membership/series/we-need-to-talk-about")
+  sealed trait Redirect
+  case class TagRedirect(tagId: String) extends Redirect
+  case class ExternalRedirect(url: String) extends Redirect
 
-  def redirect(tagId: String): Option[String] = redirectsMapping.get(tagId)
+  val redirectsMapping = Map[String, Redirect](
+    "film/series/filmweekly" -> TagRedirect("film/series/the-dailies-podcast"),
+    "technology/series/techweekly" -> TagRedirect("technology/series/chips-with-everything"),
+    "politics/series/politics-for-humans" -> TagRedirect("us-news/series/politics-for-humans"),
+    "australia-news/series/token-podcast" -> TagRedirect("society/series/token"),
+    "membership/series/guardian-live-podcast" -> TagRedirect("membership/series/we-need-to-talk-about"),
+    "music/series/reverberate" -> ExternalRedirect("https://feeds.acast.com/public/shows/e56efa7c-717d-54a0-9d42-2535caea7ccf")
+  )
+
+  def redirect(tagId: String): Option[Redirect] = redirectsMapping.get(tagId)
 
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -2,6 +2,7 @@ package com.gu.itunes
 
 import com.gu.contentapi.client.model.v1.ItemResponse
 import com.gu.contentapi.client.model.{ ContentApiError, ItemQuery }
+import com.gu.itunes.Redirection.{ExternalRedirect, TagRedirect}
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{ DateTime, DateTimeZone, Duration }
 import org.scalactic.{ Bad, Good }
@@ -39,7 +40,8 @@ class Application(val controllerComponents: ControllerComponents, val config: Co
 
     val redirect = Redirection.redirect(tagId)
     val eventualResult = redirect match {
-      case Some(redirectedTagId) => Future.successful(MovedPermanently(routes.Application.itunesRss(redirectedTagId, userApiKey).absoluteURL(true)))
+      case Some(TagRedirect(redirectedTagId)) => Future.successful(MovedPermanently(routes.Application.itunesRss(redirectedTagId, userApiKey).absoluteURL(true)))
+      case Some(ExternalRedirect(redirectUrl)) => Future.successful(MovedPermanently(redirectUrl))
       case None =>
         rawRss(tagId, userApiKey)
     }


### PR DESCRIPTION
## What does this change?

Moves Reverberate to Acast's platform instead of Acast Flex by redirecting to their RSS feed. 

This is a follow up to https://github.com/guardian/itunes-rss/pull/193