### PR TITLE
Disable flex.acast for Ashes weekly

### DIFF
--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -193,9 +193,10 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, eleme
         // pre-existing episodes that have been re-invigorated by the addition of episodic artwork, but it won't be
         // re-published. The oldest piece is expected to be from October 2022.
         AcastLaunchGroup(new DateTime(2022, 10, 1, 0, 0), Seq(
-          "news/series/guardian-australia-podcast-series")),
-        AcastLaunchGroup(new DateTime(2025, 11, 7, 0, 0), Seq(
-          "sport/series/ashespodcast")))
+          "news/series/guardian-australia-podcast-series")))
+//  Ashes Weekly has been transferred to Acast hosted platform
+//        AcastLaunchGroup(new DateTime(2025, 11, 7, 0, 0), Seq(
+//          "sport/series/ashespodcast")))
       val useAcastProxy = !adFree && acastPodcasts.find(_.tagIds.contains(tagId)).exists(p => lastModified.isAfter(p.launchDate))
       if (useAcastProxy) "https://flex.acast.com/" + url.replace("https://", "") else url
     }


### PR DESCRIPTION
In preparation for moving Ashes Weekly to Acast's platform instead of Acast Flex, we need to disable Acast Flex for this podcast.

We've done this before for Reverberate, see #193

