### PR TITLE
Add alan-jones-on-trial podcast for acast

### DIFF
--- a/app/com/gu/itunes/Redirection.scala
+++ b/app/com/gu/itunes/Redirection.scala
@@ -26,8 +26,7 @@ object Redirection {
     "australia-news/series/token-podcast" -> TagRedirect("society/series/token"),
     "membership/series/guardian-live-podcast" -> TagRedirect("membership/series/we-need-to-talk-about"),
     "music/series/reverberate" -> ExternalRedirect("https://feeds.acast.com/public/shows/e56efa7c-717d-54a0-9d42-2535caea7ccf"),
-    "sport/series/ashespodcast" -> ExternalRedirect("https://feeds.acast.com/public/shows/bf30dbed-f4f9-5d07-8ae5-479f88a4f585")
-  )
+    "sport/series/ashespodcast" -> ExternalRedirect("https://feeds.acast.com/public/shows/bf30dbed-f4f9-5d07-8ae5-479f88a4f585"))
 
   def redirect(tagId: String): Option[Redirect] = redirectsMapping.get(tagId)
 

--- a/app/com/gu/itunes/iTunesRssItem.scala
+++ b/app/com/gu/itunes/iTunesRssItem.scala
@@ -154,9 +154,9 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, eleme
           "society/series/innermost")),
         AcastLaunchGroup(new DateTime(2020, 11, 25, 0, 0), Seq(
           "australia-news/series/temporary")),
-//  Reverberate has been transferred to Acast hosted platform
-//        AcastLaunchGroup(new DateTime(2021, 1, 19, 0, 0), Seq(
-//          "music/series/reverberate")),
+        //  Reverberate has been transferred to Acast hosted platform
+        //        AcastLaunchGroup(new DateTime(2021, 1, 19, 0, 0), Seq(
+        //          "music/series/reverberate")),
         AcastLaunchGroup(new DateTime(2021, 6, 8, 0, 0), Seq(
           "lifeandstyle/series/comforteatingwithgracedent")),
         AcastLaunchGroup(new DateTime(2021, 9, 1, 0, 0), Seq(
@@ -195,10 +195,12 @@ class iTunesRssItem(val podcast: Content, val tagId: String, asset: Asset, eleme
         AcastLaunchGroup(new DateTime(2022, 10, 1, 0, 0), Seq(
           "news/series/guardian-australia-podcast-series")),
         AcastLaunchGroup(new DateTime(2026, 7, 7, 0, 0), Seq(
-          "world/series/thebirthkeepers")))
-//  Ashes Weekly has been transferred to Acast hosted platform
-//        AcastLaunchGroup(new DateTime(2025, 11, 7, 0, 0), Seq(
-//          "sport/series/ashespodcast")))
+          "world/series/thebirthkeepers")),
+        AcastLaunchGroup(new DateTime(2026, 8, 6, 0, 0), Seq(
+          "australia-news/series/alan-jones-on-trial")))
+      //  Ashes Weekly has been transferred to Acast hosted platform
+      //        AcastLaunchGroup(new DateTime(2025, 11, 7, 0, 0), Seq(
+      //          "sport/series/ashespodcast")))
       val useAcastProxy = !adFree && acastPodcasts.find(_.tagIds.contains(tagId)).exists(p => lastModified.isAfter(p.launchDate))
       if (useAcastProxy) "https://flex.acast.com/" + url.replace("https://", "") else url
     }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -2,7 +2,7 @@ package com.gu.itunes
 
 import com.gu.contentapi.client.model.v1.ItemResponse
 import com.gu.contentapi.client.model.{ ContentApiError, ItemQuery }
-import com.gu.itunes.Redirection.{ExternalRedirect, TagRedirect}
+import com.gu.itunes.Redirection.{ ExternalRedirect, TagRedirect }
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{ DateTime, DateTimeZone, Duration }
 import org.scalactic.{ Bad, Good }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Enable Acast wrapper for the Alan Jones On Trial podcast.

## How has this change been tested?

Testing on PROD FTW!

## How can we measure success?

Will check that the correct flex url has been merged into the enclosure URL.

## Have we considered potential risks?

Risks are minimal - worst case is that the URL doesn't get patched as expected.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A there is no UI here
